### PR TITLE
feat(envdoc): add profile menu and env doc panel

### DIFF
--- a/aegis/core/profile.py
+++ b/aegis/core/profile.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+
+
+@dataclass
+class Profile:
+    """Paths describing an Unreal project profile."""
+
+    engine_root: Path
+    project_dir: Path
+
+    def save(self, path: Path) -> None:
+        data = {
+            "engine_root": str(self.engine_root),
+            "project_dir": str(self.project_dir),
+        }
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> Profile:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            engine_root=Path(data["engine_root"]),
+            project_dir=Path(data["project_dir"]),
+        )

--- a/aegis/core/settings.py
+++ b/aegis/core/settings.py
@@ -1,35 +1,60 @@
-from PySide6.QtCore import QSettings, QByteArray
+from PySide6.QtCore import QByteArray, QSettings
 
 ORG = "Aegis"
 APP = "AegisToolbelt"
 
+
 class Settings:
-    def __init__(self):
+    def __init__(self) -> None:
         self.s = QSettings(ORG, APP)
 
     # theme
-    def theme_path(self) -> str | None:
-        return self.s.value("appearance/theme_path", None, type=str)
+    def theme_mode(self) -> str:
+        """Return the stored theme mode (system, light, dark, custom)."""
+        return self.s.value("appearance/theme_mode", "system", type=str)
 
-    def set_theme_path(self, path: str | None):
+    def set_theme_mode(self, mode: str) -> None:
+        self.s.setValue("appearance/theme_mode", mode)
+
+    def custom_theme_path(self) -> str | None:
+        return self.s.value("appearance/custom_theme_path", None, type=str)
+
+    def set_custom_theme_path(self, path: str | None) -> None:
         if path is None:
-            self.s.remove("appearance/theme_path")
+            self.s.remove("appearance/custom_theme_path")
         else:
-            self.s.setValue("appearance/theme_path", path)
+            self.s.setValue("appearance/custom_theme_path", path)
 
     # geometry & layout
-    def save_geometry(self, data: QByteArray):
+    def save_geometry(self, data: QByteArray) -> None:
         self.s.setValue("ui/geometry", data)
 
     def load_geometry(self) -> QByteArray | None:
         v = self.s.value("ui/geometry", None)
         return QByteArray(v) if v is not None else None
 
-    def save_state(self, data: QByteArray):
+    def save_state(self, data: QByteArray) -> None:
         self.s.setValue("ui/state", data)
 
     def load_state(self) -> QByteArray | None:
         v = self.s.value("ui/state", None)
         return QByteArray(v) if v is not None else None
+
+    def layout_version(self) -> int:
+        return self.s.value("ui/layout_version", 0, type=int)
+
+    def set_layout_version(self, version: int) -> None:
+        self.s.setValue("ui/layout_version", version)
+
+    # profile
+    def profile_path(self) -> str | None:
+        return self.s.value("profile/path", None, type=str)
+
+    def set_profile_path(self, path: str | None) -> None:
+        if path is None:
+            self.s.remove("profile/path")
+        else:
+            self.s.setValue("profile/path", path)
+
 
 settings = Settings()

--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -1,13 +1,23 @@
-from PySide6.QtWidgets import (
-    QMainWindow, QDockWidget, QWidget, QTabWidget, QTextEdit,
-    QFileDialog, QMessageBox
-)
-from PySide6.QtGui import QAction            # <-- QAction is in QtGui in PySide6
-from PySide6.QtCore import Qt
+from pathlib import Path
+import sys
 
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QGuiApplication
+from PySide6.QtWidgets import (
+    QDockWidget,
+    QFileDialog,
+    QMainWindow,
+    QMessageBox,
+    QTabWidget,
+    QTextEdit,
+)
+
+from aegis.core.profile import Profile
 from aegis.core.settings import settings
 from aegis.core.task_runner import TaskRunner
-import sys
+
+
+LAYOUT_VERSION = 2
 
 
 class MainWindow(QMainWindow):
@@ -27,57 +37,103 @@ class MainWindow(QMainWindow):
         self.tabs.addTab(QTextEdit("Trace Ops (stub)"), "Trace Ops")
 
         # Dock: Live Log
-        self.log = QTextEdit(); self.log.setReadOnly(True)
-        self.logDock = QDockWidget("Live Log"); self.logDock.setWidget(self.log)
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.logDock = QDockWidget("Live Log")
+        self.logDock.setWidget(self.log)
         self.logDock.setObjectName("dock_live_log")
-        self.addDockWidget(Qt.RightDockWidgetArea, self.logDock)
+        self.addDockWidget(Qt.BottomDockWidgetArea, self.logDock)
 
         # Dock: Artifacts
         self.artifacts = QTextEdit("Artifacts (stub)")
-        self.artDock = QDockWidget("Artifacts"); self.artDock.setWidget(self.artifacts)
+        self.artDock = QDockWidget("Artifacts")
+        self.artDock.setWidget(self.artifacts)
         self.artDock.setObjectName("dock_artifacts")
         self.addDockWidget(Qt.RightDockWidgetArea, self.artDock)
-        self.tabifyDockWidget(self.logDock, self.artDock)
-        self.logDock.raise_()
 
-        # Dock: Command Preview
-        self.preview = QTextEdit("Command Preview (stub)"); self.preview.setReadOnly(True)
-        self.previewDock = QDockWidget("Command Preview"); self.previewDock.setWidget(self.preview)
-        self.previewDock.setObjectName("dock_preview")
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.previewDock)
+        # Dock: EnvDoc
+        from aegis.ui.widgets.env_doc import EnvDocPanel
+
+        self.env_doc = EnvDocPanel()
+        self.env_dock = QDockWidget("EnvDoc")
+        self.env_dock.setWidget(self.env_doc)
+        self.env_dock.setObjectName("dock_env_doc")
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.env_dock)
 
         self.runner = TaskRunner()
+        self.profile: Profile | None = None
         self._build_menu()
         self._apply_saved_layout()
         self._apply_saved_theme()
+        self._load_last_profile()
+        QGuiApplication.styleHints().colorSchemeChanged.connect(
+            self._on_system_theme_change
+        )
 
     # ----- Menus -----
-    def _build_menu(self):
-        fileMenu = self.menuBar().addMenu("&File")
-        actNew = QAction("New Window", self); actNew.setShortcut("Ctrl+Shift+N"); fileMenu.addAction(actNew)
-        actNew.triggered.connect(self._new_window)
-        actExit = QAction("Exit", self); fileMenu.addAction(actExit); actExit.triggered.connect(self.close)
+    def _build_menu(self) -> None:
+        file_menu = self.menuBar().addMenu("&File")
+        act_new = QAction("New Window", self)
+        act_new.setShortcut("Ctrl+Shift+N")
+        file_menu.addAction(act_new)
+        act_new.triggered.connect(self._new_window)
+        act_exit = QAction("Exit", self)
+        file_menu.addAction(act_exit)
+        act_exit.triggered.connect(self.close)
 
-        viewMenu = self.menuBar().addMenu("&View")
-        actReset = QAction("Reset Layout", self); actReset.setShortcut("Ctrl+0"); viewMenu.addAction(actReset)
-        actReset.triggered.connect(self._reset_layout)
+        view_menu = self.menuBar().addMenu("&View")
+        act_reset = QAction("Reset Layout", self)
+        act_reset.setShortcut("Ctrl+0")
+        view_menu.addAction(act_reset)
+        act_reset.triggered.connect(self._reset_layout)
 
-        toolsMenu = self.menuBar().addMenu("&Tools")
-        actEcho = QAction("Echo Test Command", self); toolsMenu.addAction(actEcho)
-        actEcho.triggered.connect(self._echo_test)
+        tools_menu = self.menuBar().addMenu("&Tools")
+        act_echo = QAction("Echo Test Command", self)
+        tools_menu.addAction(act_echo)
+        act_echo.triggered.connect(self._echo_test)
 
-        settingsMenu = self.menuBar().addMenu("&Settings")
-        actTheme = QAction("Load Theme…", self); settingsMenu.addAction(actTheme)
-        actTheme.triggered.connect(self._load_theme)
+        profile_menu = self.menuBar().addMenu("&Profile")
+        act_new_profile = QAction("New", self)
+        profile_menu.addAction(act_new_profile)
+        act_new_profile.triggered.connect(self._new_profile)
+        act_open_profile = QAction("Open…", self)
+        profile_menu.addAction(act_open_profile)
+        act_open_profile.triggered.connect(self._open_profile)
+        act_save_profile = QAction("Save", self)
+        profile_menu.addAction(act_save_profile)
+        act_save_profile.triggered.connect(self._save_profile)
 
-        helpMenu = self.menuBar().addMenu("&Help")
-        actAbout = QAction("About", self); helpMenu.addAction(actAbout)
-        actAbout.triggered.connect(lambda: QMessageBox.information(self, "About", "Aegis Toolbelt — GUI helper for UE CLIs (and beyond)."))
+        settings_menu = self.menuBar().addMenu("&Settings")
+        theme_menu = settings_menu.addMenu("Load Theme…")
+        act_system = QAction("System", self)
+        theme_menu.addAction(act_system)
+        act_system.triggered.connect(lambda: self._set_theme("system"))
+        act_light = QAction("Light", self)
+        theme_menu.addAction(act_light)
+        act_light.triggered.connect(lambda: self._set_theme("light"))
+        act_dark = QAction("Dark", self)
+        theme_menu.addAction(act_dark)
+        act_dark.triggered.connect(lambda: self._set_theme("dark"))
+        act_custom = QAction("Create Custom", self)
+        theme_menu.addAction(act_custom)
+        act_custom.triggered.connect(self._create_custom_theme)
+
+        help_menu = self.menuBar().addMenu("&Help")
+        act_about = QAction("About", self)
+        help_menu.addAction(act_about)
+        act_about.triggered.connect(
+            lambda: QMessageBox.information(
+                self,
+                "About",
+                "Aegis Toolbelt — GUI helper for UE CLIs (and beyond).",
+            )
+        )
 
     # ----- Actions -----
     def _new_window(self):
         # launch a new process of this app
-        import subprocess, sys, os
+        import subprocess
+
         argv = [sys.executable, "-m", "aegis.app"]
         try:
             subprocess.Popen(argv, shell=False)
@@ -85,50 +141,141 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Error", str(e))
 
     def _reset_layout(self):
-        self.addDockWidget(Qt.RightDockWidgetArea, self.logDock)
+        self.addDockWidget(Qt.BottomDockWidgetArea, self.logDock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.artDock)
-        self.tabifyDockWidget(self.logDock, self.artDock)
-        self.addDockWidget(Qt.BottomDockWidgetArea, self.previewDock)
-        self.logDock.raise_()
+        self.addDockWidget(Qt.LeftDockWidgetArea, self.env_dock)
 
     def _echo_test(self):
         argv = [sys.executable, "-c", "print('Aegis OK')"]
-        self.log.append("[echo] Starting…")
+        self._log("[echo] Starting…", "info")
         try:
             self.runner.start(
                 argv,
-                on_stdout=lambda s: self.log.append(s),
-                on_stderr=lambda s: self.log.append(f"<span style='color:#b00;'>{s}</span>"),
-                on_exit=lambda code: self.log.append(f"[echo] Exit code: {code}")
+                on_stdout=lambda s: self._log(s, "info"),
+                on_stderr=lambda s: self._log(s, "error"),
+                on_exit=lambda code: self._log(
+                    f"[echo] Exit code: {code}", "success" if code == 0 else "error"
+                ),
             )
         except Exception as e:
             QMessageBox.critical(self, "Error", str(e))
 
-    def _load_theme(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Select .qss theme", "", "QSS (*.qss)")
+    def _new_profile(self) -> None:
+        engine = QFileDialog.getExistingDirectory(self, "Select Engine Root")
+        if not engine:
+            return
+        project = QFileDialog.getExistingDirectory(self, "Select Project Directory")
+        if not project:
+            return
+        self.profile = Profile(Path(engine), Path(project))
+        self._save_profile_as()
+
+    def _open_profile(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Open Profile", "", "JSON (*.json)")
         if path:
             try:
-                with open(path, "r", encoding="utf-8") as f:
-                    self.setStyleSheet(f.read())
-                settings.set_theme_path(path)
+                self.profile = Profile.load(Path(path))
+                settings.set_profile_path(path)
+            except Exception as e:
+                QMessageBox.critical(self, "Open Error", str(e))
+
+    def _save_profile(self) -> None:
+        if not getattr(self, "profile", None):
+            QMessageBox.information(self, "No Profile", "No profile to save.")
+            return
+        path = settings.profile_path()
+        if path:
+            try:
+                self.profile.save(Path(path))
+            except Exception as e:
+                QMessageBox.critical(self, "Save Error", str(e))
+        else:
+            self._save_profile_as()
+
+    def _save_profile_as(self) -> None:
+        if not getattr(self, "profile", None):
+            return
+        path, _ = QFileDialog.getSaveFileName(self, "Save Profile", "", "JSON (*.json)")
+        if path:
+            try:
+                self.profile.save(Path(path))
+                settings.set_profile_path(path)
+            except Exception as e:
+                QMessageBox.critical(self, "Save Error", str(e))
+
+    def _load_last_profile(self) -> None:
+        path = settings.profile_path()
+        if path and Path(path).exists():
+            try:
+                self.profile = Profile.load(Path(path))
+            except Exception:
+                self.profile = None
+
+    def _set_theme(self, mode: str) -> None:
+        settings.set_theme_mode(mode)
+        self._apply_theme()
+
+    def _create_custom_theme(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select .qss theme", "", "QSS (*.qss)"
+        )
+        if path:
+            try:
+                settings.set_theme_mode("custom")
+                settings.set_custom_theme_path(path)
+                self._apply_theme()
             except Exception as e:
                 QMessageBox.critical(self, "Theme Error", str(e))
 
     # ----- Persistence -----
     def _apply_saved_layout(self):
         g = settings.load_geometry()
-        if g: self.restoreGeometry(g)
+        if g:
+            self.restoreGeometry(g)
+        if settings.layout_version() != LAYOUT_VERSION:
+            self._reset_layout()
+            settings.set_layout_version(LAYOUT_VERSION)
+            return
         s = settings.load_state()
-        if s: self.restoreState(s)
+        if s:
+            self.restoreState(s)
 
     def _apply_saved_theme(self):
-        path = settings.theme_path()
-        if path:
-            try:
-                with open(path, "r", encoding="utf-8") as f:
+        self._apply_theme()
+
+    def _apply_theme(self, mode: str | None = None) -> None:
+        mode = mode or settings.theme_mode()
+        theme_dir = Path(__file__).parent / "themes"
+        try:
+            if mode == "system":
+                scheme = QGuiApplication.styleHints().colorScheme()
+                fname = "dark.qss" if scheme == Qt.ColorScheme.Dark else "light.qss"
+                with open(theme_dir / fname, "r", encoding="utf-8") as f:
                     self.setStyleSheet(f.read())
-            except Exception:
-                pass  # ignore if missing/moved
+            elif mode in ("light", "dark"):
+                with open(theme_dir / f"{mode}.qss", "r", encoding="utf-8") as f:
+                    self.setStyleSheet(f.read())
+            elif mode == "custom":
+                path = settings.custom_theme_path()
+                if path:
+                    with open(path, "r", encoding="utf-8") as f:
+                        self.setStyleSheet(f.read())
+        except Exception:
+            pass
+
+    def _on_system_theme_change(self) -> None:
+        if settings.theme_mode() == "system":
+            self._apply_theme("system")
+
+    def _log(self, message: str, level: str = "info") -> None:
+        colors = {
+            "info": "#888",
+            "warning": "#cc0",
+            "error": "#b00",
+            "success": "#0a0",
+        }
+        color = colors.get(level, "#888")
+        self.log.append(f"<span style='color:{color};'>{message}</span>")
 
     def closeEvent(self, ev):
         settings.save_geometry(self.saveGeometry())

--- a/aegis/ui/widgets/env_doc.py
+++ b/aegis/ui/widgets/env_doc.py
@@ -1,0 +1,10 @@
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class EnvDocPanel(QWidget):
+    """Placeholder Environment Doctor panel."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("EnvDoc (stub)"))


### PR DESCRIPTION
## Summary
- add JSON-based profile class and persist last profile path
- add Profile menu for creating, opening, and saving profiles
- introduce EnvDoc panel and include in default layout

## Testing
- `ruff check aegis/core/settings.py aegis/ui/main_window.py aegis/core/profile.py aegis/ui/widgets/env_doc.py`
- `black aegis/core/settings.py aegis/ui/main_window.py aegis/core/profile.py aegis/ui/widgets/env_doc.py --check`
- `pytest`
- `python -m py_compile aegis/core/settings.py aegis/ui/main_window.py aegis/core/profile.py aegis/ui/widgets/env_doc.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e65932e08325b7d22da1602ccbf4