### PR TITLE
feat(ui): add configurable key bindings

### DIFF
--- a/aegis/core/key_bindings.py
+++ b/aegis/core/key_bindings.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from PySide6.QtCore import QSettings
+
+DEFAULT_KEY_BINDINGS: Dict[str, str] = {
+    "file.new_window": "Ctrl+Shift+N",
+    "file.exit": "Alt+F4",
+    "view.reset_layout": "Ctrl+0",
+    "profile.new": "Ctrl+N",
+    "profile.open": "Ctrl+O",
+    "profile.save": "Ctrl+S",
+    "profile.edit": "Ctrl+E",
+}
+
+# Human readable names for UI presentation
+ACTION_NAMES: Dict[str, str] = {
+    "file.new_window": "New Window",
+    "file.exit": "Exit",
+    "view.reset_layout": "Reset Layout",
+    "profile.new": "New Profile",
+    "profile.open": "Open Profile",
+    "profile.save": "Save Profile",
+    "profile.edit": "Edit Profile",
+}
+
+
+@dataclass
+class KeyBindings:
+    settings: QSettings
+    prefix: str = "keybindings/"
+
+    def get(self, action: str) -> str:
+        return self.settings.value(
+            f"{self.prefix}{action}", DEFAULT_KEY_BINDINGS.get(action, ""), type=str
+        )
+
+    def set(self, action: str, sequence: str | None) -> None:
+        """Assign *sequence* to *action*, ensuring uniqueness."""
+        if not sequence:
+            self.settings.remove(f"{self.prefix}{action}")
+            return
+        # Remove duplicate from other actions
+        for other in DEFAULT_KEY_BINDINGS:
+            if other != action and self.get(other) == sequence:
+                self.settings.remove(f"{self.prefix}{other}")
+        self.settings.setValue(f"{self.prefix}{action}", sequence)
+
+    def all(self) -> Dict[str, str]:
+        bindings = DEFAULT_KEY_BINDINGS.copy()
+        self.settings.beginGroup("keybindings")
+        for key in self.settings.allKeys():
+            bindings[key] = self.settings.value(key, type=str)
+        self.settings.endGroup()
+        return bindings
+
+    def export_json(self, path: str) -> None:
+        import json
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.all(), f, indent=2)
+
+    def import_json(self, path: str) -> None:
+        import json
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        for action, seq in data.items():
+            if action in DEFAULT_KEY_BINDINGS:
+                self.set(action, seq)

--- a/aegis/core/settings.py
+++ b/aegis/core/settings.py
@@ -1,5 +1,7 @@
 from PySide6.QtCore import QByteArray, QSettings
 
+from aegis.core.key_bindings import KeyBindings
+
 ORG = "Aegis"
 APP = "AegisToolbelt"
 
@@ -7,6 +9,7 @@ APP = "AegisToolbelt"
 class Settings:
     def __init__(self) -> None:
         self.s = QSettings(ORG, APP)
+        self.key_bindings = KeyBindings(self.s)
 
     # theme
     def theme_mode(self) -> str:
@@ -55,5 +58,6 @@ class Settings:
             self.s.remove("profile/path")
         else:
             self.s.setValue("profile/path", path)
+
 
 settings = Settings()

--- a/aegis/ui/widgets/key_bindings_editor.py
+++ b/aegis/ui/widgets/key_bindings_editor.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QKeySequenceEdit,
+    QVBoxLayout,
+)
+
+from aegis.core.key_bindings import ACTION_NAMES
+
+
+class KeyBindingsEditor(QDialog):
+    def __init__(self, bindings: Dict[str, str], parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Key Bindings")
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.edits: Dict[str, QKeySequenceEdit] = {}
+        for action, title in ACTION_NAMES.items():
+            edit = QKeySequenceEdit()
+            seq = bindings.get(action)
+            if seq:
+                edit.setKeySequence(seq)
+            form.addRow(title, edit)
+            self.edits[action] = edit
+        layout.addLayout(form)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_bindings(self) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for action, edit in self.edits.items():
+            seq = edit.keySequence().toString()
+            result[action] = seq
+        return result


### PR DESCRIPTION
## Summary
- add KeyBindings manager with defaults and JSON import/export
- expose key binding editor in Settings
- improve profile saving to show current path

## Testing
- `python -m black --check aegis/core/key_bindings.py aegis/core/settings.py aegis/ui/main_window.py aegis/ui/widgets/key_bindings_editor.py`
- `ruff check aegis/core/key_bindings.py aegis/core/settings.py aegis/ui/main_window.py aegis/ui/widgets/key_bindings_editor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6695bea588325bf5f9f3b01ea5959