### PR TITLE
feat(ui): profile info bar and binding controls

### DIFF
--- a/aegis/ui/widgets/key_bindings_editor.py
+++ b/aegis/ui/widgets/key_bindings_editor.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 from typing import Dict
 
+from PySide6.QtGui import QKeySequence
 from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QHBoxLayout,
     QKeySequenceEdit,
+    QPushButton,
     QVBoxLayout,
+    QWidget,
 )
 
-from aegis.core.key_bindings import ACTION_NAMES
+from aegis.core.key_bindings import ACTION_NAMES, DEFAULT_KEY_BINDINGS
 
 
 class KeyBindingsEditor(QDialog):
@@ -21,18 +25,39 @@ class KeyBindingsEditor(QDialog):
         form = QFormLayout()
         self.edits: Dict[str, QKeySequenceEdit] = {}
         for action, title in ACTION_NAMES.items():
+            row = QWidget()
+            row_layout = QHBoxLayout(row)
+            row_layout.setContentsMargins(0, 0, 0, 0)
             edit = QKeySequenceEdit()
             seq = bindings.get(action)
             if seq:
                 edit.setKeySequence(seq)
-            form.addRow(title, edit)
+            btn_assign = QPushButton("Assign")
+            btn_clear = QPushButton("Clear")
+            row_layout.addWidget(edit)
+            row_layout.addWidget(btn_assign)
+            row_layout.addWidget(btn_clear)
+            form.addRow(title, row)
             self.edits[action] = edit
+            edit.keySequenceChanged.connect(
+                lambda seq, a=action: self._on_sequence_changed(a, seq)
+            )
+            btn_assign.clicked.connect(edit.setFocus)
+            btn_clear.clicked.connect(
+                lambda _=False, e=edit: e.setKeySequence(QKeySequence())
+            )
         layout.addLayout(form)
         buttons = QDialogButtonBox(
-            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+            QDialogButtonBox.Ok
+            | QDialogButtonBox.Cancel
+            | QDialogButtonBox.RestoreDefaults,
+            parent=self,
         )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
+        buttons.button(QDialogButtonBox.RestoreDefaults).clicked.connect(
+            self._reset_defaults
+        )
         layout.addWidget(buttons)
 
     def get_bindings(self) -> Dict[str, str]:
@@ -41,3 +66,20 @@ class KeyBindingsEditor(QDialog):
             seq = edit.keySequence().toString()
             result[action] = seq
         return result
+
+    def _on_sequence_changed(self, action: str, seq: QKeySequence) -> None:
+        """Ensure uniqueness by clearing duplicates in other fields."""
+        if not seq.toString():
+            return
+        for other_action, other_edit in self.edits.items():
+            if (
+                other_action != action
+                and other_edit.keySequence().toString() == seq.toString()
+            ):
+                other_edit.setKeySequence(QKeySequence())
+
+    def _reset_defaults(self) -> None:
+        """Restore edits to default key bindings."""
+        for action, edit in self.edits.items():
+            seq = DEFAULT_KEY_BINDINGS.get(action, "")
+            edit.setKeySequence(seq)

--- a/aegis/ui/widgets/profile_info_bar.py
+++ b/aegis/ui/widgets/profile_info_bar.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+from aegis.core.profile import Profile
+
+
+class ProfileInfoBar(QWidget):
+    """Display paths related to the active profile."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 2, 6, 2)
+        layout.setSpacing(12)
+        self.engine_label = QLabel()
+        self.project_label = QLabel()
+        self.profile_path_label = QLabel()
+        self.profile_name_label = QLabel()
+        for lbl in (
+            self.engine_label,
+            self.project_label,
+            self.profile_path_label,
+            self.profile_name_label,
+        ):
+            lbl.setTextInteractionFlags(Qt.TextSelectableByMouse)
+            layout.addWidget(lbl)
+        layout.addStretch()
+        self.update(None, None)
+
+    def update(self, profile: Optional[Profile], path: Optional[str]) -> None:
+        msg = "Create a profile"
+        if profile:
+            self.engine_label.setText(f"Engine: {profile.engine_root}")
+            self.project_label.setText(f"Project: {profile.project_dir}")
+            self.profile_name_label.setText(f"Profile: {profile.display_name()}" or msg)
+        else:
+            self.engine_label.setText(f"Engine: {msg}")
+            self.project_label.setText(f"Project: {msg}")
+            self.profile_name_label.setText(f"Profile: {msg}")
+        self.profile_path_label.setText(f"Profile Path: {path or msg}")


### PR DESCRIPTION
## Summary
- add assign and clear buttons in key bindings editor
- move EnvDoc into main tab stack and show profile path info bar
- expose KeyBindings.assign and .clear helpers

## Testing
- `ruff check .`
- `black --check aegis/core/key_bindings.py aegis/ui/widgets/key_bindings_editor.py aegis/ui/main_window.py aegis/ui/widgets/profile_info_bar.py`
- `pytest`
- `pip install --quiet PySide6` *(fails: Could not find a version that satisfies the requirement PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_68b66b4c152083259ffba2acd4119209