### PR TITLE
feat(ui): add task progress bar and configurable log colors

### DIFF
--- a/aegis/core/log_colors.py
+++ b/aegis/core/log_colors.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from PySide6.QtCore import QSettings
+
+DEFAULT_LEVEL_COLORS: Dict[str, str] = {
+    "info": "#888",
+    "warning": "#cc0",
+    "error": "#b00",
+    "success": "#0a0",
+}
+
+
+@dataclass
+class LogColors:
+    settings: QSettings
+    prefix: str = "log_colors"
+
+    def get_level_color(self, level: str) -> str:
+        return self.settings.value(
+            f"{self.prefix}/levels/{level}",
+            DEFAULT_LEVEL_COLORS.get(level, "#888"),
+            type=str,
+        )
+
+    def set_level_color(self, level: str, color: str) -> None:
+        self.settings.setValue(f"{self.prefix}/levels/{level}", color)
+
+    def regex_rules(self) -> List[Tuple[str, str]]:
+        data = self.settings.value(f"{self.prefix}/regex", "[]", type=str)
+        try:
+            raw = json.loads(data)
+        except Exception:
+            raw = []
+        rules: List[Tuple[str, str]] = []
+        for entry in raw[:5]:
+            pattern = entry.get("pattern")
+            color = entry.get("color")
+            if pattern and color:
+                rules.append((pattern, color))
+        return rules
+
+    def set_regex_rules(self, rules: List[Tuple[str, str]]) -> None:
+        payload = [{"pattern": p, "color": c} for p, c in rules if p and c][:5]
+        self.settings.setValue(f"{self.prefix}/regex", json.dumps(payload))
+
+    def color_for(self, message: str, level: str) -> str:
+        for pattern, color in self.regex_rules():
+            try:
+                if re.search(pattern, message):
+                    return color
+            except re.error:
+                continue
+        return self.get_level_color(level)
+
+    def export_json(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.all(), f, indent=2)
+
+    def import_json(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        levels = data.get("levels", {})
+        for level, color in levels.items():
+            if level in DEFAULT_LEVEL_COLORS:
+                self.set_level_color(level, color)
+        regex_list = []
+        for entry in data.get("regex", [])[:5]:
+            pattern = entry.get("pattern")
+            color = entry.get("color")
+            if pattern and color:
+                regex_list.append((pattern, color))
+        self.set_regex_rules(regex_list)
+
+    def all(self) -> Dict[str, object]:
+        return {
+            "levels": {
+                level: self.get_level_color(level) for level in DEFAULT_LEVEL_COLORS
+            },
+            "regex": [{"pattern": p, "color": c} for p, c in self.regex_rules()],
+        }
+
+    def reset(self) -> None:
+        self.settings.beginGroup(self.prefix)
+        self.settings.remove("")
+        self.settings.endGroup()

--- a/aegis/core/settings.py
+++ b/aegis/core/settings.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import QByteArray, QSettings
 
 from aegis.core.key_bindings import KeyBindings
+from aegis.core.log_colors import LogColors
 
 ORG = "Aegis"
 APP = "AegisToolbelt"
@@ -10,6 +11,7 @@ class Settings:
     def __init__(self) -> None:
         self.s = QSettings(ORG, APP)
         self.key_bindings = KeyBindings(self.s)
+        self.log_colors = LogColors(self.s)
 
     # theme
     def theme_mode(self) -> str:

--- a/aegis/core/task_runner.py
+++ b/aegis/core/task_runner.py
@@ -2,27 +2,41 @@ import subprocess
 import threading
 from typing import Callable, List, Optional
 
-class TaskRunner:
+from PySide6.QtCore import QObject, Signal
+
+
+class TaskRunner(QObject):
+    """Minimal non-blocking subprocess runner.
+
+    Emits ``started`` when a task begins and ``finished`` with the exit code
+    when the task completes. Only a single task can run at a time.
     """
-    Minimal non-blocking subprocess runner.
-    - No shell=True
-    - Streams stdout/stderr via callbacks
-    """
-    def __init__(self):
+
+    started = Signal()
+    finished = Signal(int)
+
+    def __init__(self) -> None:
+        super().__init__()
         self._proc: Optional[subprocess.Popen] = None
 
-    def start(self,
-              argv: List[str],
-              on_stdout: Callable[[str], None],
-              on_stderr: Callable[[str], None],
-              on_exit: Callable[[int], None]):
+    def start(
+        self,
+        argv: List[str],
+        on_stdout: Callable[[str], None],
+        on_stderr: Callable[[str], None],
+        on_exit: Callable[[int], None],
+    ):
         if self._proc:
             raise RuntimeError("A task is already running")
 
         self._proc = subprocess.Popen(
-            argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, shell=False
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            shell=False,
         )
+        self.started.emit()
 
         def pump(stream, cb):
             assert stream is not None
@@ -43,6 +57,7 @@ class TaskRunner:
             code = self._proc.wait()
             self._proc = None
             on_exit(code)
+            self.finished.emit(code)
 
         threading.Thread(target=wait_and_finish, daemon=True).start()
 
@@ -50,4 +65,3 @@ class TaskRunner:
         if self._proc:
             self._proc.terminate()
             self._proc = None
-

--- a/aegis/ui/widgets/log_colors_editor.py
+++ b/aegis/ui/widgets/log_colors_editor.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLineEdit,
+    QVBoxLayout,
+)
+
+from aegis.core.log_colors import DEFAULT_LEVEL_COLORS
+
+
+class LogColorsEditor(QDialog):
+    def __init__(
+        self,
+        levels: Dict[str, str],
+        regex: List[Tuple[str, str]],
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Log Colors")
+        layout = QVBoxLayout(self)
+
+        # Level colors
+        form = QFormLayout()
+        self.level_edits: Dict[str, QLineEdit] = {}
+        for level in ["info", "warning", "error", "success"]:
+            edit = QLineEdit(levels.get(level, ""))
+            form.addRow(level.capitalize(), edit)
+            self.level_edits[level] = edit
+        layout.addLayout(form)
+
+        # Regex colors
+        group = QGroupBox("Regex Colors")
+        group_layout = QVBoxLayout(group)
+        self.regex_edits: List[Tuple[QLineEdit, QLineEdit]] = []
+        for i in range(5):
+            row = QHBoxLayout()
+            pat = QLineEdit()
+            col = QLineEdit()
+            if i < len(regex):
+                pat.setText(regex[i][0])
+                col.setText(regex[i][1])
+            row.addWidget(pat, 3)
+            row.addWidget(col, 1)
+            group_layout.addLayout(row)
+            self.regex_edits.append((pat, col))
+        layout.addWidget(group)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok
+            | QDialogButtonBox.Cancel
+            | QDialogButtonBox.RestoreDefaults,
+            parent=self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        buttons.button(QDialogButtonBox.RestoreDefaults).clicked.connect(
+            self._reset_defaults
+        )
+        layout.addWidget(buttons)
+
+    def get_config(self) -> Tuple[Dict[str, str], List[Tuple[str, str]]]:
+        levels = {level: edit.text() for level, edit in self.level_edits.items()}
+        regex: List[Tuple[str, str]] = []
+        for pat, col in self.regex_edits:
+            if pat.text() and col.text():
+                regex.append((pat.text(), col.text()))
+        return levels, regex
+
+    def _reset_defaults(self) -> None:
+        for level, edit in self.level_edits.items():
+            edit.setText(DEFAULT_LEVEL_COLORS[level])
+        for pat, col in self.regex_edits:
+            pat.clear()
+            col.clear()


### PR DESCRIPTION
## Summary
- update window title to include profile nickname and project
- add log clear button with search and filter options
- add task progress bar with cancel and UAFT token prompts
- allow configuring log colors with level and regex rules

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat unrelated files)*
- `black --check aegis/core/log_colors.py aegis/ui/widgets/log_colors_editor.py aegis/core/settings.py aegis/ui/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71ea81cc483258208106e2ed76174