### PR TITLE
feat(ui): add about/help and feedback dialogs

### DIFF
--- a/aegis/ui/widgets/env_fix_dialog.py
+++ b/aegis/ui/widgets/env_fix_dialog.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class EnvFixDialog(QDialog):
+    """Dialog to select environment fix scripts."""
+
+    def __init__(self, scripts: dict[str, Path], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Fix Environment")
+        self._scripts = scripts
+        self._checks: dict[str, QCheckBox] = {}
+
+        layout = QVBoxLayout(self)
+        for name, path in scripts.items():
+            cb = QCheckBox(f"{name} (" + str(path) + ")")
+            cb.setChecked(True)
+            self._checks[name] = cb
+            layout.addWidget(cb)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def selected_scripts(self) -> list[Path]:
+        return [
+            self._scripts[name] for name, cb in self._checks.items() if cb.isChecked()
+        ]

--- a/aegis/ui/widgets/feedback_dialog.py
+++ b/aegis/ui/widgets/feedback_dialog.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QTextEdit,
+)
+
+
+class FeedbackDialog(QDialog):
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Provide Feedback")
+        layout = QFormLayout(self)
+        self.subject_edit = QLineEdit()
+        self.message_edit = QTextEdit()
+        layout.addRow("Subject:", self.subject_edit)
+        layout.addRow("Feedback:", self.message_edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        layout.addWidget(buttons)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+    def get_feedback(self) -> tuple[str, str]:
+        return self.subject_edit.text(), self.message_edit.toPlainText()

--- a/aegis/ui/widgets/help_dialog.py
+++ b/aegis/ui/widgets/help_dialog.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QTextEdit, QVBoxLayout
+
+
+class HelpDialog(QDialog):
+    def __init__(self, readme_path: Path, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Help")
+        layout = QVBoxLayout(self)
+        text = QTextEdit()
+        text.setReadOnly(True)
+        try:
+            with open(readme_path, "r", encoding="utf-8") as f:
+                text.setPlainText(f.read())
+        except Exception as e:  # pragma: no cover - best effort
+            text.setPlainText(str(e))
+        layout.addWidget(text)
+        buttons = QDialogButtonBox(QDialogButtonBox.Close)
+        layout.addWidget(buttons)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)


### PR DESCRIPTION
## Summary
- add Help menu with About, Provide Feedback, and Help actions
- show version, author, repo link, and license in About dialog
- display README content in in-app Help dialog and open email client for feedback

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/core/profile.py, aegis/ui/widgets/profile_editor.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b729fe30308325854d85adbe4720ce