### PR TITLE
feat(env-doc, uaft): add token watcher and optional tool checks

### DIFF
--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -1,0 +1,31 @@
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from aegis.modules.uaft import Uaft
+
+
+def make_ini(path: Path, token: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        """
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
+securityToken={}
+""".format(
+            token
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_security_token_updates(tmp_path: Path) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    make_ini(ini, "AAA")
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "AAA"
+    time.sleep(1.1)
+    make_ini(ini, "BBB")
+    time.sleep(1.5)
+    assert uaft.security_token() == "BBB"
+    uaft.stop()


### PR DESCRIPTION
## Summary
- auto-refresh UAFT security token from DefaultEngine.ini
- extend EnvDoc with per-component fixes and optional tool detection
- add SDK requirement tester and highlight optional Vulkan SDK

## Testing
- `ruff check .`
- `black --check aegis/modules/uaft.py aegis/ui/widgets/env_doc.py tests/test_uaft.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b733164d40832582a18d2dd02647ff