### PR TITLE
fix(env, uaft, ui): parse engine sdk reqs, security token, launch logcat tool

### DIFF
--- a/aegis/core/ini_parser.py
+++ b/aegis/core/ini_parser.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+IniData = Dict[str, Dict[str, str]]
+
+
+def parse_ini(path: Path) -> IniData:
+    """Parse a simple INI file into a nested dict.
+
+    Supports multiple sections in ``[section]`` form and ``;`` comments.
+    Inline comments are stripped. Values are kept as strings.
+    """
+    data: IniData = {}
+    current: Dict[str, str] | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split(";", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            sect = line[1:-1].strip()
+            current = data.setdefault(sect, {})
+            continue
+        if current is None or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        current[key.strip()] = val.strip()
+    return data

--- a/aegis/modules/uaft.py
+++ b/aegis/modules/uaft.py
@@ -32,6 +32,10 @@ class Uaft:
     def _config_path(self) -> Path | None:
         if not self.project_dir:
             return None
+        for folder in ("Config", "Configs"):
+            cfg = self.project_dir / folder / "DefaultEngine.ini"
+            if cfg.exists():
+                return cfg
         return self.project_dir / "Config" / "DefaultEngine.ini"
 
     def _read_token(self) -> str | None:

--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -42,3 +42,11 @@ SecurityToken=Key=ZZZ
     uaft = Uaft(Path("uaft"), project_dir=tmp_path)
     assert uaft.security_token() == "ZZZ"
     uaft.stop()
+
+
+def test_security_token_configs_dir(tmp_path: Path) -> None:
+    ini = tmp_path / "Configs" / "DefaultEngine.ini"
+    make_ini(ini, "CCC")
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "CCC"
+    uaft.stop()


### PR DESCRIPTION
## Summary
- parse Android SDK/NDK requirements from DefaultEngine.ini, diffing against installed platforms and build-tools while honoring `latest`
- load UAFT security token from DefaultEngine.ini and pass project path to Uaft helper
- launch Android Studio's Logcat viewer via `studio logcat` instead of maintaining a custom viewer

## Testing
- `ruff check .`
- `black --check .` (fails: would reformat aegis/app.py, aegis/core/profile.py, aegis/ui/widgets/profile_editor.py)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75340cae08325bef2b365c776d684