### PR TITLE
fix(core): centralize UE ini parser

### DIFF
--- a/aegis/core/ini_parser.py
+++ b/aegis/core/ini_parser.py
@@ -1,29 +1,64 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
 
-IniData = Dict[str, Dict[str, str]]
+IniData = Dict[str, Dict[str, List[Optional[str]]]]
 
 
 def parse_ini(path: Path) -> IniData:
-    """Parse a simple INI file into a nested dict.
+    """Parse an Unreal Engine ``.ini`` file applying special operators.
 
-    Supports multiple sections in ``[section]`` form and ``;`` comments.
-    Inline comments are stripped. Values are kept as strings.
+    Unreal configuration files support line prefixes that modify how values are
+    merged:
+
+    ``+`` adds a line only if the property is missing, ``-`` removes exact
+    matches, ``.`` always appends a new line, and ``!`` deletes a property by
+    name. Semicolons are treated as literal characters rather than comments.
+
+    Returns a nested mapping of ``section -> key -> list of values``. A value is
+    ``None`` when the line had no ``=`` delimiter (flag-style entries).
     """
+
     data: IniData = {}
-    current: Dict[str, str] | None = None
+    section: str | None = None
     for raw in path.read_text(encoding="utf-8").splitlines():
-        line = raw.split(";", 1)[0].strip()
+        line = raw.strip()
         if not line:
             continue
         if line.startswith("[") and line.endswith("]"):
-            sect = line[1:-1].strip()
-            current = data.setdefault(sect, {})
+            section = line[1:-1].strip()
+            data.setdefault(section, {})
             continue
-        if current is None or "=" not in line:
+        if section is None:
             continue
-        key, val = line.split("=", 1)
-        current[key.strip()] = val.strip()
+        prefix = ""
+        if line[0] in "+-!.":
+            prefix, line = line[0], line[1:]
+        key, sep, value = line.partition("=")
+        key = key.strip()
+        value = value.strip() if sep else None
+        sec = data.setdefault(section, {})
+        existing = sec.get(key)
+        if prefix == "+":
+            if not existing:
+                sec[key] = [value]
+        elif prefix == "-":
+            if existing:
+                sec[key] = [v for v in existing if v != value]
+                if not sec[key]:
+                    sec.pop(key)
+        elif prefix == ".":
+            sec.setdefault(key, []).append(value)
+        elif prefix == "!":
+            sec.pop(key, None)
+        else:
+            sec[key] = [value]
     return data
+
+
+def get_value(data: IniData, section: str, key: str) -> str | None:
+    """Return the last surviving value for ``section/key`` or ``None``."""
+
+    values = data.get(section, {}).get(key)
+    return values[-1] if values else None

--- a/aegis/modules/uaft.py
+++ b/aegis/modules/uaft.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from dataclasses import dataclass, field
-import configparser
 import threading
 import time
+
+from aegis.core.ini_parser import get_value, parse_ini
 
 
 @dataclass
@@ -42,15 +43,12 @@ class Uaft:
         cfg_path = self._config_path()
         if not cfg_path or not cfg_path.exists():
             return None
-        cfg = configparser.ConfigParser()
-        cfg.read(cfg_path)
+        cfg = parse_ini(cfg_path)
         sec = "/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings"
-        if cfg.has_section(sec):
-            token = cfg.get(sec, "SecurityToken", fallback=None)
-            if token and "=" in token:
-                token = token.split("=", 1)[1].strip()
-            return token
-        return None
+        token = get_value(cfg, sec, "SecurityToken")
+        if token and "=" in token:
+            token = token.split("=", 1)[1].strip()
+        return token
 
     def _watch_token(self) -> None:
         while not self._stop_evt.is_set():

--- a/aegis/ui/widgets/env_doc.py
+++ b/aegis/ui/widgets/env_doc.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import (
 
 from aegis.core.profile import Profile
 from aegis.core.task_runner import TaskRunner
-from aegis.core.ini_parser import parse_ini
+from aegis.core.ini_parser import get_value, parse_ini
 from .env_fix_dialog import EnvFixDialog
 
 
@@ -335,12 +335,12 @@ class EnvDocPanel(QWidget):
             self.log("[env] DefaultEngine.ini not found", "error")
             return
         data = parse_ini(cfg_path)
-        section = data.get("/Script/AndroidRuntimeSettings.AndroidRuntimeSettings", {})
-        min_sdk = section.get("MinSDKVersion")
-        target_sdk = section.get("TargetSDKVersion")
-        sdk_override = section.get("SDKAPILevelOverride")
-        ndk_override = section.get("NDKAPILevelOverride")
-        build_tools_req = section.get("BuildToolsVersion")
+        sect = "/Script/AndroidRuntimeSettings.AndroidRuntimeSettings"
+        min_sdk = get_value(data, sect, "MinSDKVersion")
+        target_sdk = get_value(data, sect, "TargetSDKVersion")
+        sdk_override = get_value(data, sect, "SDKAPILevelOverride")
+        ndk_override = get_value(data, sect, "NDKAPILevelOverride")
+        build_tools_req = get_value(data, sect, "BuildToolsVersion")
         platforms = self._find_platforms_dir()
         installed: list[int] = []
         if platforms and platforms.exists():

--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -50,3 +50,75 @@ def test_security_token_configs_dir(tmp_path: Path) -> None:
     uaft = Uaft(Path("uaft"), project_dir=tmp_path)
     assert uaft.security_token() == "CCC"
     uaft.stop()
+
+
+def test_security_token_duplicate_options(tmp_path: Path) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    ini.parent.mkdir(parents=True, exist_ok=True)
+    ini.write_text(
+        """
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
+SecurityToken=DDD
+[/Script/WindowsTargetPlatform.WindowsTargetSettings]
++d3d12targetedshaderformats=PCD3D_SM6
++d3d12targetedshaderformats=PCD3D_SM5
+""",
+        encoding="utf-8",
+    )
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "DDD"
+    uaft.stop()
+
+
+def test_security_token_flag_without_value(tmp_path: Path) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    ini.parent.mkdir(parents=True, exist_ok=True)
+    ini.write_text(
+        """
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
+SecurityToken=EEE
+[/Script/WindowsTargetPlatform.WindowsTargetSettings]
++d3d12targetedshaderformats=PCD3D_SM6
++UseShaderCompilerWorker
+""",
+        encoding="utf-8",
+    )
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "EEE"
+    uaft.stop()
+
+
+def test_security_token_special_operators(tmp_path: Path) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    ini.parent.mkdir(parents=True, exist_ok=True)
+    ini.write_text(
+        """
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
+SecurityToken=AAA
++SecurityToken=BBB
+.SecurityToken=CCC
+-SecurityToken=CCC
+!SecurityToken
+.SecurityToken=DDD
+""",
+        encoding="utf-8",
+    )
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "DDD"
+    uaft.stop()
+
+
+def test_security_token_plus_only(tmp_path: Path) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    ini.parent.mkdir(parents=True, exist_ok=True)
+    ini.write_text(
+        """
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
++SecurityToken=AAA
++SecurityToken=BBB
+""",
+        encoding="utf-8",
+    )
+    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
+    assert uaft.security_token() == "AAA"
+    uaft.stop()


### PR DESCRIPTION
## Summary
- move Unreal Engine .ini parser into core so it handles +, -, ., ! operators and flag lines
- reuse the shared parser in UAFT and environment doctor

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/core/profile.py, aegis/ui/widgets/profile_editor.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76052857c8325b13c51f6b0f2a254