### PR TITLE
feat(env): improve SDK fixes and feedback

### DIFF
--- a/aegis/ui/widgets/env_fix_dialog.py
+++ b/aegis/ui/widgets/env_fix_dialog.py
@@ -6,6 +6,8 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QDialog,
     QDialogButtonBox,
+    QFileDialog,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -17,22 +19,43 @@ class EnvFixDialog(QDialog):
     def __init__(self, scripts: dict[str, Path], parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Fix Environment")
-        self._scripts = scripts
+        self._scripts: dict[str, Path] = {}
         self._checks: dict[str, QCheckBox] = {}
 
-        layout = QVBoxLayout(self)
-        for name, path in scripts.items():
-            cb = QCheckBox(f"{name} (" + str(path) + ")")
-            cb.setChecked(True)
-            self._checks[name] = cb
-            layout.addWidget(cb)
+        self._layout = QVBoxLayout(self)
+        self._add_button = QPushButton("Add Script…")
+        self._add_button.clicked.connect(self._prompt_add_scripts)
+        self._layout.addWidget(self._add_button)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
-        layout.addWidget(buttons)
+        self._layout.addWidget(buttons)
+
+        for name, path in scripts.items():
+            self.add_script(path, name)
 
     def selected_scripts(self) -> list[Path]:
         return [
             self._scripts[name] for name, cb in self._checks.items() if cb.isChecked()
         ]
+
+    def _prompt_add_scripts(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(self, "Select scripts")
+        for p in paths:
+            self.add_script(Path(p))
+
+    def add_script(self, path: Path, name: str | None = None) -> None:
+        if not name:
+            base = path.name
+            name = base
+            idx = 2
+            while name in self._scripts:
+                name = f"{base} ({idx})"
+                idx += 1
+        self._scripts[name] = path
+        cb = QCheckBox(f"{name} (" + str(path) + ")")
+        cb.setChecked(True)
+        self._checks[name] = cb
+        index = self._layout.indexOf(self._add_button)
+        self._layout.insertWidget(index, cb)

--- a/tests/test_env_doc_versions.py
+++ b/tests/test_env_doc_versions.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtWidgets import QApplication
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.ui.widgets.env_doc import EnvDocPanel
+from aegis.ui.widgets.env_fix_dialog import EnvFixDialog
+
+
+@pytest.fixture(scope="module")
+def app() -> QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _panel() -> EnvDocPanel:
+    return EnvDocPanel(TaskRunner(), lambda *_: None)
+
+
+def test_detect_android_sdk_version(app: QApplication, tmp_path: Path) -> None:
+    platforms = tmp_path / "platforms"
+    platforms.mkdir()
+    (platforms / "android-30").mkdir()
+    (platforms / "android-33").mkdir()
+    panel = _panel()
+    version, color = panel._detect_version("Android SDK", tmp_path)
+    assert version == "33"
+    assert color is None
+
+
+def test_detect_android_ndk_version(app: QApplication, tmp_path: Path) -> None:
+    ndk_dir = tmp_path / "25.2.9519653"
+    ndk_dir.mkdir()
+    panel = _panel()
+    version, color = panel._detect_version("Android NDK", ndk_dir)
+    assert version == "25.2.9519653"
+    assert color is None
+
+
+def test_detect_vulkan_sdk_version(app: QApplication, tmp_path: Path) -> None:
+    vulkan_dir = tmp_path / "1.3.250.0"
+    vulkan_dir.mkdir()
+    panel = _panel()
+    version, color = panel._detect_version("Vulkan SDK", vulkan_dir)
+    assert version == "1.3.250.0"
+    assert color is None
+
+
+def test_retest_sdks_logs(app: QApplication, tmp_path: Path) -> None:
+    logs: list[tuple[str, str]] = []
+    engine = tmp_path / "eng"
+    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
+    (engine / "Extras" / "Android" / "NDK").mkdir(parents=True)
+    (engine / "Extras" / "Android" / "JDK").mkdir(parents=True)
+    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
+    panel.update_profile(Profile(engine, tmp_path))
+    logs.clear()
+    panel._retest_sdks()
+    assert logs[-1] == (
+        "[env] Re-Test SDK installations and Environment variables complete",
+        "success",
+    )
+
+
+def test_retest_sdks_logs_failed(app: QApplication, tmp_path: Path) -> None:
+    logs: list[tuple[str, str]] = []
+    engine = tmp_path / "eng_fail"
+    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
+    (engine / "Extras" / "Android" / "JDK").mkdir(parents=True)
+    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
+    panel.update_profile(Profile(engine, tmp_path))
+    logs.clear()
+    panel._retest_sdks()
+    assert logs[-1] == (
+        "[env] Re-Test SDK installations and Environment variables failed",
+        "error",
+    )
+
+
+def test_engine_compat_sdk_test_logs(app: QApplication, tmp_path: Path) -> None:
+    logs: list[tuple[str, str]] = []
+    engine = tmp_path / "eng_ec"
+    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
+    (engine / "Extras" / "Android" / "NDK").mkdir(parents=True)
+    (engine / "Extras" / "Android" / "JDK").mkdir(parents=True)
+    proj = tmp_path / "proj"
+    cfg = proj / "Config"
+    cfg.mkdir(parents=True)
+    (cfg / "DefaultEngine.ini").write_text(
+        "[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]\n", "utf-8"
+    )
+    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
+    panel.update_profile(Profile(engine, proj))
+    logs.clear()
+    panel._test_sdk(True)
+    assert logs[-1] == (
+        "[env] Engine Compatibility SDK test complete",
+        "success",
+    )
+
+
+def test_engine_compat_sdk_test_failed(app: QApplication, tmp_path: Path) -> None:
+    logs: list[tuple[str, str]] = []
+    engine = tmp_path / "eng_ec_fail"
+    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
+    proj = tmp_path / "proj_fail"
+    cfg = proj / "Config"
+    cfg.mkdir(parents=True)
+    (cfg / "DefaultEngine.ini").write_text(
+        "[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]\nMinSDKVersion=33\n",
+        "utf-8",
+    )
+    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
+    panel.update_profile(Profile(engine, proj))
+    logs.clear()
+    panel._test_sdk(True)
+    assert logs[-1] == (
+        "[env] Engine Compatibility SDK test failed",
+        "error",
+    )
+
+
+def test_env_fix_dialog_add_scripts(app: QApplication, tmp_path: Path) -> None:
+    dlg = EnvFixDialog({})
+    s1 = tmp_path / "one.bat"
+    s2 = tmp_path / "two.exe"
+    s1.write_text("", "utf-8")
+    s2.write_text("", "utf-8")
+    dlg.add_script(s1)
+    dlg.add_script(s2)
+    selected = dlg.selected_scripts()
+    assert s1 in selected and s2 in selected
+
+
+def test_run_scripts_noninteractive(app: QApplication, tmp_path: Path) -> None:
+    panel = EnvDocPanel(TaskRunner(), lambda *_: None)
+    captured: list[list[str]] = []
+
+    def fake_start(argv, on_stdout=None, on_stderr=None, on_exit=None):
+        captured.append(argv)
+        if on_exit:
+            on_exit(0)
+
+    panel.runner.start = fake_start  # type: ignore[assignment]
+    script = tmp_path / "dummy.exe"
+    script.write_text("", "utf-8")
+    panel._run_scripts([script])
+    assert captured[0][-1] == "-noninteractive"


### PR DESCRIPTION
## Summary
- drop unused Logcat viewer entry
- preview log color changes in real time
- keep log dock visible while resizing
- compute Android SDK version from highest platform directory
- derive Android NDK and Vulkan SDK versions from path names
- rename Test SDK button to Re-Test all SDKs and log completion status
- summarize Engine Compatibility SDK test results
- support adding custom fix scripts and run them non-interactively
- label log entries with severity and test NDK version detection

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/core/profile.py, aegis/ui/widgets/profile_editor.py)*
- `pip install PySide6` *(fails: Could not find a version that satisfies the requirement PySide6; Tunnel connection failed: 403 Forbidden)*
- `pytest` *(7 passed, 2 skipped: could not import 'PySide6')*


------
https://chatgpt.com/codex/tasks/task_e_68b7684ecde48325a9344f2d95d88a9d