### PR TITLE
fix(ui): improve log dock, UAFT path, env doc, and panel scaling

### DIFF
--- a/aegis/ui/widgets/env_doc.py
+++ b/aegis/ui/widgets/env_doc.py
@@ -64,10 +64,6 @@ class EnvDocPanel(QWidget):
         self.test_button.clicked.connect(self._retest_sdks)
         layout.addWidget(self.test_button)
 
-        self.test_compat_button = QPushButton("Test SDK (Engine Compatibility)")
-        self.test_compat_button.clicked.connect(lambda: self._test_sdk(True))
-        layout.addWidget(self.test_compat_button)
-
         self.fix_button = QPushButton("Fix Env")
         self.fix_button.clicked.connect(self._fix_env)
         layout.addWidget(self.fix_button)

--- a/aegis/ui/widgets/log_colors_editor.py
+++ b/aegis/ui/widgets/log_colors_editor.py
@@ -33,7 +33,7 @@ class ColorButton(QPushButton):
 
     def _choose_color(self) -> None:
         original = QColor(self._color)
-        dlg = QColorDialog(self._color, self)
+        dlg = QColorDialog(self._color, self.window())
         dlg.currentColorChanged.connect(self._preview_color)
         if dlg.exec():
             self._color = dlg.currentColor()

--- a/aegis/ui/widgets/uaft_panel.py
+++ b/aegis/ui/widgets/uaft_panel.py
@@ -107,6 +107,9 @@ class UaftPanel(QWidget):
         self.pull_dir = QLineEdit()
         self.pull_base: Path | None = None
         self.btn_choose_dir = QPushButton("Choose Folder…")
+        self.chk_auto_path = QCheckBox("Auto path")
+        self.chk_auto_path.setChecked(True)
+        self.chk_auto_path.setToolTip("Path will change on device selection")
         self.btn_pull = QPushButton("Pull Selected Trace")
         self.chk_open_insights = QCheckBox("Open in Unreal Insights after pull")
 
@@ -171,6 +174,7 @@ class UaftPanel(QWidget):
                     QLabel("Pull to:"),
                     self.pull_dir,
                     self.btn_choose_dir,
+                    self.chk_auto_path,
                     self.btn_pull,
                     self.chk_open_insights,
                 ]
@@ -197,6 +201,7 @@ class UaftPanel(QWidget):
         self.btn_refresh_traces.clicked.connect(self._refresh_traces)
         self.btn_choose_dir.clicked.connect(self._choose_dir)
         self.btn_pull.clicked.connect(self._pull_trace)
+        self.chk_auto_path.toggled.connect(lambda _checked: self._device_selected())
 
     # ----- Profile -----
     def update_profile(self, profile: Optional[Profile]) -> None:
@@ -205,6 +210,7 @@ class UaftPanel(QWidget):
         self._apply_project_prefix()
         self._load_security_token()
         self._apply_pull_base()
+        self._device_selected()
 
     def _apply_project_prefix(self) -> None:
         if not self.profile:
@@ -339,8 +345,10 @@ class UaftPanel(QWidget):
             self.serial.setText(serial)
             make = self.device_table.item(row, 0).text()
             model = self.device_table.item(row, 1).text()
-            if self.pull_base:
-                self.pull_dir.setText(str(self.pull_base / f"{make}{model}"))
+            if self.pull_base and self.chk_auto_path.isChecked():
+                make_safe = make.replace(" ", "_")
+                model_safe = model.replace(" ", "_")
+                self.pull_dir.setText(str(self.pull_base / f"{make_safe}_{model_safe}"))
 
     def _list_packages(self) -> None:
         uaft = self._require_uaft()

--- a/tests/test_env_doc_versions.py
+++ b/tests/test_env_doc_versions.py
@@ -87,49 +87,6 @@ def test_retest_sdks_logs_failed(app: QApplication, tmp_path: Path) -> None:
     )
 
 
-def test_engine_compat_sdk_test_logs(app: QApplication, tmp_path: Path) -> None:
-    logs: list[tuple[str, str]] = []
-    engine = tmp_path / "eng_ec"
-    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
-    (engine / "Extras" / "Android" / "NDK").mkdir(parents=True)
-    (engine / "Extras" / "Android" / "JDK").mkdir(parents=True)
-    proj = tmp_path / "proj"
-    cfg = proj / "Config"
-    cfg.mkdir(parents=True)
-    (cfg / "DefaultEngine.ini").write_text(
-        "[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]\n", "utf-8"
-    )
-    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
-    panel.update_profile(Profile(engine, proj))
-    logs.clear()
-    panel._test_sdk(True)
-    assert logs[-1] == (
-        "[env] Engine Compatibility SDK test complete",
-        "success",
-    )
-
-
-def test_engine_compat_sdk_test_failed(app: QApplication, tmp_path: Path) -> None:
-    logs: list[tuple[str, str]] = []
-    engine = tmp_path / "eng_ec_fail"
-    (engine / "Extras" / "Android" / "SDK").mkdir(parents=True)
-    proj = tmp_path / "proj_fail"
-    cfg = proj / "Config"
-    cfg.mkdir(parents=True)
-    (cfg / "DefaultEngine.ini").write_text(
-        "[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]\nMinSDKVersion=33\n",
-        "utf-8",
-    )
-    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
-    panel.update_profile(Profile(engine, proj))
-    logs.clear()
-    panel._test_sdk(True)
-    assert logs[-1] == (
-        "[env] Engine Compatibility SDK test failed",
-        "error",
-    )
-
-
 def test_env_fix_dialog_add_scripts(app: QApplication, tmp_path: Path) -> None:
     dlg = EnvFixDialog({})
     s1 = tmp_path / "one.bat"


### PR DESCRIPTION
## Summary
- allow Live Log dock to float and drop obsolete Artifacts panel
- auto-fill UAFT trace pull path with selected device make_model and optional override checkbox
- remove Test SDK (Engine Compatibility) button from Environment Doctor
- prevent color picker dialog from inheriting preview color
- keep EnvDoc and UAFT panels centered with widths scaling to window size

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/core/profile.py, aegis/ui/widgets/profile_editor.py)*
- `black --check aegis/ui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7738aa6308325aaba6a613ff3944d