### PR TITLE
fix(ui): expand panels and widen path fields

### DIFF
--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -61,15 +61,11 @@ class MainWindow(QMainWindow):
         self.env_doc = EnvDocPanel(self.runner, self._log)
         env_container = QWidget()
         env_layout = QVBoxLayout(env_container)
-        env_layout.setAlignment(Qt.AlignTop)
-        env_layout.addWidget(self.env_doc, alignment=Qt.AlignHCenter)
-        env_layout.addStretch(1)
+        env_layout.addWidget(self.env_doc, 1)
         self.uaft_panel = UaftPanel(self.runner, self._log)
         uaft_container = QWidget()
         uaft_layout = QVBoxLayout(uaft_container)
-        uaft_layout.setAlignment(Qt.AlignTop)
-        uaft_layout.addWidget(self.uaft_panel, alignment=Qt.AlignHCenter)
-        uaft_layout.addStretch(1)
+        uaft_layout.addWidget(self.uaft_panel, 1)
         self.tabs.addTab(env_container, "EnvDoc")
         self.tabs.addTab(QTextEdit("Build (stub)"), "Build")
         self.tabs.addTab(QTextEdit("Commandlets (stub)"), "Commandlets")
@@ -84,7 +80,6 @@ class MainWindow(QMainWindow):
         central_layout.addWidget(self.info_bar)
         central_layout.addWidget(self.tabs)
         self.setCentralWidget(central)
-        self._update_panel_widths()
 
         # Status bar with progress and cancel button
         self.status = QStatusBar()
@@ -153,15 +148,7 @@ class MainWindow(QMainWindow):
 
     def resizeEvent(self, event):  # type: ignore[override]
         super().resizeEvent(event)
-        self._update_panel_widths()
         self._reset_log_dock_size()
-
-    def _update_panel_widths(self) -> None:
-        central_width = (
-            self.centralWidget().width() if self.centralWidget() else self.width()
-        )
-        self.env_doc.setMaximumWidth(central_width)
-        self.uaft_panel.setMaximumWidth(central_width)
 
     def _reset_log_dock_size(self) -> None:
         self.logDock.setMinimumSize(0, 0)
@@ -520,6 +507,8 @@ class MainWindow(QMainWindow):
         g = settings.load_geometry()
         if g:
             self.restoreGeometry(g)
+        else:
+            self.setWindowState(self.windowState() | Qt.WindowMaximized)
         if settings.layout_version() != LAYOUT_VERSION:
             self._reset_layout()
             settings.set_layout_version(LAYOUT_VERSION)

--- a/aegis/ui/widgets/env_doc.py
+++ b/aegis/ui/widgets/env_doc.py
@@ -14,6 +14,7 @@ from typing import Callable, Optional
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QDialog,
+    QHeaderView,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -57,7 +58,17 @@ class EnvDocPanel(QWidget):
                 "Actions",
             ]
         )
-        self.table.horizontalHeader().setStretchLastSection(True)
+        header = self.table.horizontalHeader()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.Stretch)
+        header.setSectionResizeMode(4, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(5, QHeaderView.ResizeToContents)
+        header.resizeSection(0, 200)
+        header.resizeSection(1, 500)
+        header.resizeSection(3, 150)
         layout.addWidget(self.table)
 
         self.test_button = QPushButton("Re-Test all SDKs")

--- a/aegis/ui/widgets/uaft_panel.py
+++ b/aegis/ui/widgets/uaft_panel.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 
 from aegis.core.profile import Profile
@@ -105,6 +106,8 @@ class UaftPanel(QWidget):
         self.trace_list.setSelectionMode(QListWidget.SingleSelection)
         self.trace_list.setMinimumHeight(160)
         self.pull_dir = QLineEdit()
+        self.pull_dir.setMinimumContentsLength(250)
+        self.pull_dir.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         self.pull_base: Path | None = None
         self.btn_choose_dir = QPushButton("Choose Folder…")
         self.chk_auto_path = QCheckBox("Auto path")


### PR DESCRIPTION
## Summary
- let EnvDoc and UAFT panels stretch to fill the tab area and start the window maximized on first run
- show complete UAFT pull paths by expanding the input to ~250 characters
- widen EnvDoc table columns so component, path, and status stay visible while action buttons remain compact

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat app.py, profile.py, widgets/profile_editor.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a3ff981083259c303de3ec92237b