### PR TITLE
feat(ui): enhance batch builder panel

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 This project exists thanks to the contributions of the following people:
 
+- OpenAI
 - Rahul
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # Aegis-A-UE-GUI-Toolbelt-for-UE-CLI
 
 A cross-platform PySide6 GUI toolbelt that turns Unreal Engine command-line tools into one-click workflows. It supports theming,
- dockable panes, live logs, command previews, and is built for future expansion.
+dockable panes, live logs, command previews, and is built for future expansion.
 
 Powered with - PySide6
+
+## Features
+
+- **Batch builder** – queue Clean, Build, Rebuild, Cook, Stage, Package and DDC tasks. Each step shows per-task and overall progress,
+  supports reordering, and can be cancelled at any time.
+- **Config & platform profiles** – project profiles persist custom build configurations and target platforms in their JSON files.
+- **UBT & UAT helpers** – generate `Build.bat/.sh` and `RunUAT.bat/.sh` commands with exact CLI previews, resolving Engine paths and
+  logging missing files.
+- **UAFT traces** – run trace captures using arguments from `UECommandline.txt`.
 
 ## Quick start
 
@@ -16,6 +25,24 @@ python -m aegis.app
 ```
 
 ## Usage
+
+### Batch builder
+
+Use the **Batch Builder** panel to assemble a sequence of build steps:
+
+1. Clean
+2. Build (iterative)
+3. Rebuild (clean build)
+4. Cook
+5. Stage
+6. Package
+7. Derived Data Cache (build/clean/rebuild)
+
+Each step can optionally clean its output directory before running. Tasks start from the selected profile's
+build configuration and target platform, and the exact command line for each step is shown so you can copy
+and reuse it in scripts. Unstarted tasks can be reordered or removed, and running tasks can be cancelled.
+
+### UAFT traces
 
 The UAFT module reads trace arguments from `UECommandline.txt`. A sample file is provided with the following contents:
 

--- a/aegis/core/profile.py
+++ b/aegis/core/profile.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import json
 
@@ -12,12 +12,16 @@ class Profile:
     engine_root: Path
     project_dir: Path
     nickname: str = ""
+    build_configs: list[str] = field(default_factory=list)
+    build_platforms: list[str] = field(default_factory=list)
 
     def save(self, path: Path) -> None:
         data = {
             "engine_root": str(self.engine_root),
             "project_dir": str(self.project_dir),
             "nickname": self.nickname,
+            "build_configs": self.build_configs,
+            "build_platforms": self.build_platforms,
         }
         path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
@@ -28,6 +32,8 @@ class Profile:
             engine_root=Path(data["engine_root"]),
             project_dir=Path(data["project_dir"]),
             nickname=data.get("nickname", ""),
+            build_configs=data.get("build_configs", []),
+            build_platforms=data.get("build_platforms", []),
         )
 
     def display_name(self) -> str:
@@ -35,4 +41,3 @@ class Profile:
         nick = self.nickname.strip()
         proj = self.project_dir.name
         return f"{nick}-{proj}" if nick else proj
-

--- a/aegis/modules/uat.py
+++ b/aegis/modules/uat.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import logging
+import sys
+
+
+@dataclass
+class Uat:
+    """Thin UAT command helper for BuildCookRun and DDC tasks.
+
+    Flags live in
+    ``Engine/Source/Programs/AutomationTool/Scripts/BuildCookRun.Automation.cs``.
+    """
+
+    engine_root: Path
+    project_dir: Path
+
+    logger = logging.getLogger(__name__)
+
+    def _engine_dir(self) -> Path:
+        root = self.engine_root
+        if (root / "Build" / "BatchFiles").exists():
+            self.logger.debug("Using engine directory %s", root)
+            return root
+        candidate = root / "Engine"
+        if (candidate / "Build" / "BatchFiles").exists():
+            self.logger.debug("Detected engine root %s", root)
+            return candidate
+        msg = f"Could not locate Engine/Build/BatchFiles under {root}"
+        self.logger.error(msg)
+        raise FileNotFoundError(msg)
+
+    def _exe(self) -> Path:
+        script = "RunUAT.bat" if sys.platform.startswith("win") else "RunUAT.sh"
+        return self._engine_dir() / "Build" / "BatchFiles" / script
+
+    def _uproject(self) -> Path:
+        for p in self.project_dir.glob("*.uproject"):
+            self.logger.debug("Using uproject %s", p)
+            return p
+        msg = f"No .uproject file found in {self.project_dir}"
+        self.logger.error(msg)
+        raise FileNotFoundError(msg)
+
+    def buildcookrun_argv(
+        self,
+        platform: str,
+        config: str,
+        *,
+        build: bool = False,
+        cook: bool = False,
+        stage: bool = False,
+        package: bool = False,
+        skip_build: bool = False,
+        skip_cook: bool = False,
+        skip_stage: bool = False,
+    ) -> list[str]:
+        argv = [
+            str(self._exe()),
+            "BuildCookRun",
+            f"-Project={self._uproject()}",
+            "-NoP4",
+            f"-ClientConfig={config}",
+            f"-TargetPlatform={platform}",
+        ]
+        if build:
+            argv.append("-Build")
+        elif skip_build:
+            argv.append("-SkipBuild")
+        if cook:
+            argv.append("-Cook")
+        elif skip_cook:
+            argv.append("-SkipCook")
+        if stage:
+            argv.append("-Stage")
+        elif skip_stage:
+            argv.append("-SkipStage")
+        if package:
+            argv.append("-Package")
+        return argv
+
+    def build_ddc_argv(self, platform: str, clean: bool = False) -> list[str]:
+        argv = [
+            str(self._exe()),
+            "BuildDerivedDataCache",
+            f"-Project={self._uproject()}",
+            f"-TargetPlatform={platform}",
+        ]
+        if clean:
+            argv.append("-Clean")
+        return argv
+
+    def rebuild_ddc_argv(self, platform: str) -> list[str]:
+        argv = self.build_ddc_argv(platform, clean=True)
+        argv.append("-Fill")
+        return argv

--- a/aegis/modules/ubt.py
+++ b/aegis/modules/ubt.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Ubt:
+    """Tiny helper to build Unreal Build Tool commands."""
+
+    engine_root: Path
+    project_dir: Path
+
+    logger = logging.getLogger(__name__)
+
+    def _engine_dir(self) -> Path:
+        root = self.engine_root
+        if (root / "Build" / "BatchFiles").exists():
+            self.logger.debug("Using engine directory %s", root)
+            return root
+        candidate = root / "Engine"
+        if (candidate / "Build" / "BatchFiles").exists():
+            self.logger.debug("Detected engine root %s", root)
+            return candidate
+        msg = f"Could not locate Engine/Build/BatchFiles under {root}"
+        self.logger.error(msg)
+        raise FileNotFoundError(msg)
+
+    def _uproject(self) -> Path:
+        for p in self.project_dir.glob("*.uproject"):
+            self.logger.debug("Using uproject %s", p)
+            return p
+        msg = f"No .uproject file found in {self.project_dir}"
+        self.logger.error(msg)
+        raise FileNotFoundError(msg)
+
+    def build_argv(
+        self,
+        target: str,
+        platform: str,
+        config: str,
+        clean: bool = False,
+    ) -> list[str]:
+        script_dir = self._engine_dir() / "Build" / "BatchFiles"
+        script = script_dir / ("Build.bat" if sys.platform == "win32" else "Build.sh")
+        argv = [str(script)]
+        if clean:
+            argv.append("-clean")
+        argv += [
+            target,
+            platform,
+            config,
+            f"-Project={self._uproject()}",
+            "-WaitMutex",
+            "-FromMsBuild",
+        ]
+        return argv
+
+    def guess_target(self, config: str) -> tuple[str, str]:
+        name = self.project_dir.name
+        if config.endswith("Editor"):
+            return f"{name}Editor", config[:-6]
+        if config.endswith("Server"):
+            return f"{name}Server", config[:-6]
+        return name, config

--- a/aegis/ui/widgets/batch_builder_panel.py
+++ b/aegis/ui/widgets/batch_builder_panel.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import sys
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional, Set
+import shutil
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QProgressBar,
+    QAbstractItemView,
+)
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.modules.ubt import Ubt
+from aegis.modules.uat import Uat
+
+
+# Include server and editor configurations by default
+DEFAULT_CONFIGS = [
+    "Debug",
+    "DebugGame",
+    "DebugServer",
+    "DebugEditor",
+    "Development",
+    "DevelopmentServer",
+    "DevelopmentEditor",
+    "Test",
+    "TestServer",
+    "TestEditor",
+    "Shipping",
+    "ShippingServer",
+    "ShippingEditor",
+]
+
+# Mac is included for editor builds
+DEFAULT_PLATFORMS = ["Win64", "Linux", "Mac", "Android"]
+
+
+@dataclass
+class QueuedTask:
+    tag: str
+    config: str
+    platform: str
+    item: QListWidgetItem
+    widget: QWidget
+    bar: QProgressBar
+    clean: bool = False
+
+
+class BatchBuilderPanel(QWidget):
+    """Batch builder UI with queued tasks and progress tracking."""
+
+    batch_started = Signal(int)
+    batch_progress = Signal(int)
+    batch_finished = Signal()
+
+    def __init__(
+        self,
+        runner: TaskRunner,
+        log_cb: Callable[[str, str], None],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.runner = runner
+        self.log = log_cb
+        self.profile: Profile | None = None
+        self.ubt: Ubt | None = None
+        self.uat: Uat | None = None
+
+        self.tasks: list[QueuedTask] = []
+        self.current_index = -1
+        self.cancel_requested = False
+
+        layout = QHBoxLayout(self)
+
+        # ----- Configs -----
+        cfg_layout = QVBoxLayout()
+        cfg_layout.addWidget(QLabel("Config"))
+        self.config_list = QListWidget()
+        self.config_list.setSelectionMode(QListWidget.SingleSelection)
+        self.config_list.currentTextChanged.connect(self._on_config_changed)
+        cfg_layout.addWidget(self.config_list)
+        btn_add_cfg = QPushButton("Add…")
+        btn_add_cfg.clicked.connect(self._add_config)
+        cfg_layout.addWidget(btn_add_cfg)
+        layout.addLayout(cfg_layout)
+
+        # ----- Platforms -----
+        plat_layout = QVBoxLayout()
+        plat_layout.addWidget(QLabel("Platform"))
+        self.platform_list = QListWidget()
+        self.platform_list.setSelectionMode(QListWidget.SingleSelection)
+        plat_layout.addWidget(self.platform_list)
+        btn_add_plat = QPushButton("Add…")
+        btn_add_plat.clicked.connect(self._add_platform)
+        plat_layout.addWidget(btn_add_plat)
+        layout.addLayout(plat_layout)
+
+        # ----- Actions -----
+        act_layout = QVBoxLayout()
+        btn_clean = QPushButton("Clean")
+        btn_build = QPushButton("Build")
+        btn_rebuild = QPushButton("Rebuild")
+        btn_cook = QPushButton("Cook")
+        btn_stage = QPushButton("Stage")
+        btn_package = QPushButton("Package")
+        btn_ddc_build = QPushButton("Build DDC")
+        btn_ddc_clean = QPushButton("Clean DDC")
+        btn_ddc_rebuild = QPushButton("Rebuild DDC")
+        for text, btn in [
+            ("clean", btn_clean),
+            ("build", btn_build),
+            ("rebuild", btn_rebuild),
+            ("cook", btn_cook),
+            ("stage", btn_stage),
+            ("package", btn_package),
+            ("ddc-build", btn_ddc_build),
+            ("ddc-clean", btn_ddc_clean),
+            ("ddc-rebuild", btn_ddc_rebuild),
+        ]:
+            act_layout.addWidget(btn)
+            btn.clicked.connect(lambda _, t=text: self._queue_task(t))
+        act_layout.addStretch()
+        layout.addLayout(act_layout)
+
+        # ----- Queue -----
+        queue_layout = QVBoxLayout()
+        queue_layout.addWidget(QLabel("Queued Tasks"))
+        self.task_list = QListWidget()
+        self.task_list.setSelectionMode(QAbstractItemView.SingleSelection)
+        queue_layout.addWidget(self.task_list)
+        row = QHBoxLayout()
+        btn_up = QPushButton("Up")
+        btn_down = QPushButton("Down")
+        btn_remove = QPushButton("Remove")
+        btn_start = QPushButton("Start")
+        btn_cancel = QPushButton("Cancel")
+        btn_up.clicked.connect(lambda: self._move_task(-1))
+        btn_down.clicked.connect(lambda: self._move_task(1))
+        btn_remove.clicked.connect(self._remove_task)
+        btn_start.clicked.connect(self._start_batch)
+        btn_cancel.clicked.connect(self.cancel_batch)
+        for b in (btn_up, btn_down, btn_remove, btn_start, btn_cancel):
+            row.addWidget(b)
+        queue_layout.addLayout(row)
+        layout.addLayout(queue_layout)
+
+    # ----- Profile -----
+    def update_profile(self, profile: Profile | None) -> None:
+        self.profile = profile
+        self.ubt = Ubt(profile.engine_root, profile.project_dir) if profile else None
+        self.uat = Uat(profile.engine_root, profile.project_dir) if profile else None
+        self.config_list.clear()
+        self.platform_list.clear()
+        if not profile:
+            cfgs = DEFAULT_CONFIGS
+            plats = DEFAULT_PLATFORMS
+        else:
+            cfgs = profile.build_configs or DEFAULT_CONFIGS
+            plats = profile.build_platforms or DEFAULT_PLATFORMS
+        for c in cfgs:
+            self.config_list.addItem(QListWidgetItem(c))
+        for p in plats:
+            self.platform_list.addItem(QListWidgetItem(p))
+        if self.config_list.count():
+            self.config_list.setCurrentRow(0)
+
+    # ----- Configs/Platforms -----
+    def _add_config(self) -> None:
+        name, ok = QInputDialog.getText(self, "Add Config", "Config name:")
+        if ok and name:
+            self.config_list.addItem(QListWidgetItem(name))
+            if self.profile:
+                self.profile.build_configs = self._current_configs()
+
+    def _add_platform(self) -> None:
+        name, ok = QInputDialog.getText(self, "Add Platform", "Platform name:")
+        if ok and name:
+            self.platform_list.addItem(QListWidgetItem(name))
+            if self.profile:
+                self.profile.build_platforms = self._current_platforms()
+
+    def _current_configs(self) -> list[str]:
+        return [
+            self.config_list.item(i).text() for i in range(self.config_list.count())
+        ]
+
+    def _current_platforms(self) -> list[str]:
+        return [
+            self.platform_list.item(i).text() for i in range(self.platform_list.count())
+        ]
+
+    def _allowed_platforms_for_config(self, cfg: str) -> Optional[Set[str]]:
+        if cfg.endswith("Editor"):
+            return {"Win64", "Linux", "Mac"}
+        return None
+
+    def _on_config_changed(self, text: str) -> None:
+        allowed = self._allowed_platforms_for_config(text)
+        for i in range(self.platform_list.count()):
+            item = self.platform_list.item(i)
+            if allowed and item.text() not in allowed:
+                item.setHidden(True)
+            else:
+                item.setHidden(False)
+
+    # ----- Queue management -----
+    def _queue_task(self, tag: str) -> None:
+        cfg_item = self.config_list.currentItem()
+        plat_item = self.platform_list.currentItem()
+        if not cfg_item or not plat_item:
+            self.log("[batch] Select config and platform", "error")
+            return
+        if "Editor" in cfg_item.text() and plat_item.text() not in {
+            "Win64",
+            "Linux",
+            "Mac",
+        }:
+            self.log("[batch] Editor builds require Win64, Linux, or Mac", "error")
+            return
+        clean = False
+        if tag in {"cook", "stage", "package"}:
+            mode, ok = QInputDialog.getItem(
+                self,
+                "Mode",
+                "Mode:",
+                ["Iterative", "Clean"],
+                0,
+                False,
+            )
+            if not ok:
+                return
+            clean = mode == "Clean"
+        widget = QWidget()
+        row = QHBoxLayout(widget)
+        label = f"{tag} {cfg_item.text()} {plat_item.text()}"
+        if clean:
+            label += " (clean)"
+        row.addWidget(QLabel(label))
+        bar = QProgressBar()
+        bar.setRange(0, 1)
+        bar.setValue(0)
+        row.addWidget(bar)
+        item = QListWidgetItem()
+        item.setSizeHint(widget.sizeHint())
+        self.task_list.addItem(item)
+        self.task_list.setItemWidget(item, widget)
+        self.tasks.append(
+            QueuedTask(tag, cfg_item.text(), plat_item.text(), item, widget, bar, clean)
+        )
+
+    def _move_task(self, delta: int) -> None:
+        row = self.task_list.currentRow()
+        if row == -1 or row <= self.current_index:
+            return
+        new_row = row + delta
+        if (
+            new_row <= self.current_index
+            or new_row >= self.task_list.count()
+            or new_row < 0
+        ):
+            return
+        task = self.tasks.pop(row)
+        self.tasks.insert(new_row, task)
+        item = self.task_list.takeItem(row)
+        self.task_list.insertItem(new_row, item)
+        self.task_list.setItemWidget(item, task.widget)
+        self.task_list.setCurrentRow(new_row)
+
+    def _remove_task(self) -> None:
+        row = self.task_list.currentRow()
+        if row == -1 or row <= self.current_index:
+            return
+        self.tasks.pop(row)
+        self.task_list.takeItem(row)
+
+    def _start_batch(self) -> None:
+        if self.current_index != -1 or not self.tasks:
+            return
+        self.current_index = -1
+        self.cancel_requested = False
+        self.batch_started.emit(len(self.tasks))
+        self._run_next_task()
+
+    def cancel_batch(self) -> None:
+        if self.current_index == -1:
+            return
+        self.cancel_requested = True
+        self.runner.cancel()
+
+    def _run_next_task(self) -> None:
+        self.current_index += 1
+        if self.current_index >= len(self.tasks):
+            self.current_index = -1
+            self.batch_finished.emit()
+            return
+        task = self.tasks[self.current_index]
+        task.bar.setRange(0, 0)
+        try:
+            argv = self._argv_for(task)
+        except Exception as e:
+            self.log(f"[{task.tag}] {e}", "error")
+            self._task_done(task, -1)
+            return
+        self.log(
+            f"[batch] {' '.join(shlex.quote(a) for a in argv)}",
+            "info",
+        )
+        try:
+            self.runner.start(
+                argv,
+                on_stdout=lambda s: self.log(f"[{task.tag}] {s}", "info"),
+                on_stderr=lambda s: self.log(f"[{task.tag}] {s}", "error"),
+                on_exit=lambda code: self._task_done(task, code),
+            )
+        except Exception as e:
+            self.log(f"[{task.tag}] {e}", "error")
+            self._task_done(task, -1)
+
+    def _argv_for(self, task: QueuedTask) -> list[str]:
+        if not self.profile or not self.ubt:
+            raise RuntimeError("No profile loaded")
+        if task.tag in {"build", "clean", "rebuild"}:
+            target, cfg = self.ubt.guess_target(task.config)
+            clean = task.tag != "build"
+            return self.ubt.build_argv(target, task.platform, cfg, clean)
+        if not self.uat:
+            raise RuntimeError("No profile loaded")
+        if task.tag == "cook":
+            if task.clean:
+                self._clean_dir(self.profile.project_dir / "Saved" / "Cooked")
+            return self.uat.buildcookrun_argv(
+                task.platform,
+                task.config,
+                cook=True,
+                skip_build=True,
+            )
+        if task.tag == "stage":
+            if task.clean:
+                self._clean_dir(self.profile.project_dir / "Saved" / "Staged")
+            return self.uat.buildcookrun_argv(
+                task.platform,
+                task.config,
+                stage=True,
+                skip_build=True,
+                skip_cook=True,
+            )
+        if task.tag == "package":
+            if task.clean:
+                self._clean_dir(self.profile.project_dir / "Saved" / "Staged")
+            return self.uat.buildcookrun_argv(
+                task.platform,
+                task.config,
+                package=True,
+                skip_build=True,
+                skip_cook=True,
+                skip_stage=True,
+            )
+        if task.tag == "ddc-build":
+            return self.uat.build_ddc_argv(task.platform)
+        if task.tag == "ddc-clean":
+            return self.uat.build_ddc_argv(task.platform, clean=True)
+        if task.tag == "ddc-rebuild":
+            return self.uat.rebuild_ddc_argv(task.platform)
+        return [
+            sys.executable,
+            "-c",
+            f"print('{task.tag} {task.config} {task.platform}')",
+        ]
+
+    def _clean_dir(self, path: Path) -> None:
+        if path.exists():
+            shutil.rmtree(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+    def _task_done(self, task: QueuedTask, code: int) -> None:
+        task.bar.setRange(0, 1)
+        task.bar.setValue(1 if code == 0 else 0)
+        self.log(f"[{task.tag}] exit code {code}", "success" if code == 0 else "error")
+        self.batch_progress.emit(self.current_index + 1)
+        if self.cancel_requested:
+            self.current_index = -1
+            self.batch_finished.emit()
+        else:
+            self._run_next_task()

--- a/tests/test_batch_defaults.py
+++ b/tests/test_batch_defaults.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+import pytest
+
+pytest.importorskip("PySide6")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aegis.ui.widgets.batch_builder_panel import DEFAULT_CONFIGS, DEFAULT_PLATFORMS
+
+
+def test_default_configs_include_server_and_editor():
+    assert "DevelopmentServer" in DEFAULT_CONFIGS
+    assert "DevelopmentEditor" in DEFAULT_CONFIGS
+
+
+def test_default_platforms_include_mac():
+    assert "Mac" in DEFAULT_PLATFORMS

--- a/tests/test_profile_custom_fields.py
+++ b/tests/test_profile_custom_fields.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aegis.core.profile import Profile
+
+
+def test_profile_roundtrip(tmp_path):
+    path = tmp_path / "profile.json"
+    prof = Profile(
+        engine_root=Path("/Engine"),
+        project_dir=Path("/Project"),
+        nickname="nick",
+        build_configs=["Development", "Shipping"],
+        build_platforms=["Win64", "Linux"],
+    )
+    prof.save(path)
+    loaded = Profile.load(path)
+    assert loaded.build_configs == ["Development", "Shipping"]
+    assert loaded.build_platforms == ["Win64", "Linux"]
+    assert loaded.nickname == "nick"

--- a/tests/test_uat.py
+++ b/tests/test_uat.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aegis.modules.uat import Uat
+
+
+def _setup(tmp_path: Path) -> tuple[Path, Path]:
+    engine_root = tmp_path / "UE"
+    (engine_root / "Engine/Build/BatchFiles").mkdir(parents=True)
+    project_dir = tmp_path / "MyGame"
+    project_dir.mkdir()
+    (project_dir / "MyGame.uproject").write_text("", encoding="utf-8")
+    return engine_root, project_dir
+
+
+def test_cook_argv_skips_build(tmp_path: Path) -> None:
+    engine_root, project_dir = _setup(tmp_path)
+    uat = Uat(engine_root, project_dir)
+    argv = uat.buildcookrun_argv("Win64", "Development", cook=True, skip_build=True)
+    assert argv[0] == str(engine_root / "Engine/Build/BatchFiles/RunUAT.sh")
+    assert "-Cook" in argv
+    assert "-SkipBuild" in argv
+
+
+def test_ddc_clean_argv(tmp_path: Path) -> None:
+    engine_root, project_dir = _setup(tmp_path)
+    uat = Uat(engine_root, project_dir)
+    argv = uat.build_ddc_argv("Win64", clean=True)
+    assert argv[1] == "BuildDerivedDataCache"
+    assert "-Clean" in argv
+
+
+def test_ddc_rebuild_adds_fill(tmp_path: Path) -> None:
+    engine_root, project_dir = _setup(tmp_path)
+    uat = Uat(engine_root, project_dir)
+    argv = uat.rebuild_ddc_argv("Win64")
+    assert "-Clean" in argv and "-Fill" in argv
+
+
+def test_engine_path_direct(tmp_path: Path) -> None:
+    engine_root, project_dir = _setup(tmp_path)
+    uat = Uat(engine_root / "Engine", project_dir)
+    argv = uat.build_ddc_argv("Win64")
+    assert argv[0] == str(engine_root / "Engine/Build/BatchFiles/RunUAT.sh")

--- a/tests/test_ubt.py
+++ b/tests/test_ubt.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aegis.modules.ubt import Ubt
+
+
+def test_build_argv_includes_clean_and_project(tmp_path):
+    engine_root = tmp_path / "UE"
+    (engine_root / "Engine/Build/BatchFiles").mkdir(parents=True)
+    project_dir = tmp_path / "MyGame"
+    project_dir.mkdir()
+    (project_dir / "MyGame.uproject").write_text("", encoding="utf-8")
+    ubt = Ubt(engine_root, project_dir)
+    target, cfg = ubt.guess_target("DevelopmentEditor")
+    argv = ubt.build_argv(target, "Win64", cfg, clean=True)
+    assert argv[0] == str(engine_root / "Engine/Build/BatchFiles/Build.sh")
+    assert argv[1] == "-clean"
+    assert argv[2] == "MyGameEditor"
+    assert argv[3] == "Win64"
+    assert argv[4] == "Development"
+    assert f"-Project={project_dir / 'MyGame.uproject'}" in argv
+
+
+def test_engine_path_direct(tmp_path):
+    engine_root = tmp_path / "UE"
+    (engine_root / "Engine/Build/BatchFiles").mkdir(parents=True)
+    project_dir = tmp_path / "MyGame"
+    project_dir.mkdir()
+    (project_dir / "MyGame.uproject").write_text("", encoding="utf-8")
+    ubt = Ubt(engine_root / "Engine", project_dir)
+    argv = ubt.build_argv("MyGame", "Win64", "Development")
+    assert argv[0] == str(engine_root / "Engine/Build/BatchFiles/Build.sh")


### PR DESCRIPTION
## Summary
- expand default build configs to include server and editor variants and add Mac platform
- queue batch tasks with per-step progress, reordering and cancellation
- track batch completion in main window progress bar
- generate UBT build commands for clean/build/rebuild based on active profile
- wire UAT BuildCookRun and DDC helpers into batch builder with optional clean/iterative steps
- resolve Engine vs Engine/Build paths for UAT/UBT helpers and log missing files
- document build tool workflow and credits in README and CONTRIBUTORS

## Testing
- `ruff check .`
- `black --check .` (fails: would reformat aegis/app.py, aegis/ui/widgets/profile_editor.py)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7b120eb6483259d4a51c049d8832f