### PR TITLE
feat(ui): wrap manual override descriptions

### DIFF
--- a/aegis/ui/widgets/manual_override_dialog.py
+++ b/aegis/ui/widgets/manual_override_dialog.py
@@ -236,11 +236,14 @@ class ManualOverrideDialog(QDialog):
         self.table = QTableWidget(0, 4)
         self.table.setHorizontalHeaderLabels(["Use", "Switch", "Description", "Value"])
         self.table.verticalHeader().setVisible(False)
+        self.table.setWordWrap(True)
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(3, QHeaderView.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeToContents)
+        fm = self.table.fontMetrics()
+        self.table.verticalHeader().setDefaultSectionSize(fm.lineSpacing() * 3)
         layout.addWidget(self.table)
 
         for row, switch in enumerate(sorted(BUILD_COOK_RUN_SWITCHES)):
@@ -257,7 +260,7 @@ class ManualOverrideDialog(QDialog):
             self.table.setCellWidget(row, 3, val)
 
         self.table.resizeColumnsToContents()
-        self.resize(900, 600)
+        self.resize(1100, 700)
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)


### PR DESCRIPTION
## Summary
- wrap manual override descriptions to three lines
- enlarge manual override dialog for better readability

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/ui/widgets/profile_editor.py)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aegis')*

------
https://chatgpt.com/codex/tasks/task_e_68ba745b27a08325830a4944d3cd5cd1