### PR TITLE
feat(batch): inline command editor

### DIFF
--- a/aegis/ui/widgets/batch_builder_panel.py
+++ b/aegis/ui/widgets/batch_builder_panel.py
@@ -55,6 +55,16 @@ DEFAULT_CONFIGS = [
 # Mac is included for editor builds
 DEFAULT_PLATFORMS = ["Win64", "Linux", "Mac", "Android"]
 
+# Tasks that support manual command editing
+EDITABLE_TAGS = {
+    "cook",
+    "stage",
+    "package",
+    "ddc-build",
+    "ddc-clean",
+    "ddc-rebuild",
+}
+
 
 @dataclass
 class QueuedTask:
@@ -75,6 +85,7 @@ class BatchBuilderPanel(QWidget):
     batch_started = Signal(int)
     batch_progress = Signal(int)
     batch_finished = Signal()
+    tasks_changed = Signal()
 
     def __init__(
         self,
@@ -186,14 +197,23 @@ class BatchBuilderPanel(QWidget):
         btn_up = QPushButton("Up")
         btn_down = QPushButton("Down")
         btn_remove = QPushButton("Remove")
+        btn_edit_all = QPushButton("Edit All")
         btn_start = QPushButton("Start")
         btn_cancel = QPushButton("Cancel")
         btn_up.clicked.connect(lambda: self._move_task(-1))
         btn_down.clicked.connect(lambda: self._move_task(1))
         btn_remove.clicked.connect(self._remove_task)
+        btn_edit_all.clicked.connect(self._check_all_edits)
         btn_start.clicked.connect(self._start_batch)
         btn_cancel.clicked.connect(self.cancel_batch)
-        for b in (btn_up, btn_down, btn_remove, btn_start, btn_cancel):
+        for b in (
+            btn_up,
+            btn_down,
+            btn_remove,
+            btn_edit_all,
+            btn_start,
+            btn_cancel,
+        ):
             row.addWidget(b)
         queue_layout.addLayout(row)
         layout.addLayout(queue_layout)
@@ -342,7 +362,13 @@ class BatchBuilderPanel(QWidget):
         widget = QWidget()
         row = QHBoxLayout(widget)
         edit_chk = QCheckBox("Edit")
-        edit_chk.setToolTip("Edit command before running")
+        edit_chk.setAutoExclusive(False)
+        edit_chk.setTristate(False)
+        if tag not in EDITABLE_TAGS:
+            edit_chk.setEnabled(False)
+            edit_chk.setToolTip("Manual edit not available")
+        else:
+            edit_chk.setToolTip("Edit command before running")
         row.addWidget(edit_chk)
         label = f"{tag} {cfg_item.text()} {plat_item.text()}"
         if clean:
@@ -367,6 +393,7 @@ class BatchBuilderPanel(QWidget):
             self.task_list.takeItem(self.task_list.row(item))
             return
         self.tasks.append(task)
+        self.tasks_changed.emit()
 
     def _move_task(self, delta: int) -> None:
         row = self.task_list.currentRow()
@@ -385,6 +412,7 @@ class BatchBuilderPanel(QWidget):
         self.task_list.insertItem(new_row, item)
         self.task_list.setItemWidget(item, task.widget)
         self.task_list.setCurrentRow(new_row)
+        self.tasks_changed.emit()
 
     def _remove_task(self) -> None:
         row = self.task_list.currentRow()
@@ -392,6 +420,13 @@ class BatchBuilderPanel(QWidget):
             return
         self.tasks.pop(row)
         self.task_list.takeItem(row)
+        self.tasks_changed.emit()
+
+    def _check_all_edits(self) -> None:
+        """Tick edit boxes for all editable tasks."""
+        for task in self.tasks:
+            if task.edit.isEnabled():
+                task.edit.setChecked(True)
 
     def command_preview(self, row: int) -> str:
         if row < 0 or row >= len(self.tasks):
@@ -404,7 +439,9 @@ class BatchBuilderPanel(QWidget):
         cmd = " ".join(shlex.quote(a) for a in argv)
         return task.cmd_override or cmd
 
-    def set_command_override(self, row: int, cmd: str | None) -> None:
+    def set_command_override(
+        self, row: int, cmd: str | None, *, emit: bool = True
+    ) -> None:
         if row < 0 or row >= len(self.tasks):
             return
         task = self.tasks[row]
@@ -417,6 +454,14 @@ class BatchBuilderPanel(QWidget):
                 task.item.setToolTip(" ".join(shlex.quote(a) for a in argv))
             except Exception:
                 task.item.setToolTip("")
+        if emit:
+            self.tasks_changed.emit()
+
+    def task_is_editable(self, row: int) -> bool:
+        return 0 <= row < len(self.tasks) and self.tasks[row].tag in EDITABLE_TAGS
+
+    def all_command_previews(self) -> list[str]:
+        return [self.command_preview(i) for i in range(len(self.tasks))]
 
     def _start_batch(self) -> None:
         if self.current_index != -1 or not self.tasks:
@@ -442,6 +487,7 @@ class BatchBuilderPanel(QWidget):
                 else:
                     task.item.setToolTip(default_cmd)
                 task.edit.setChecked(False)
+        self.tasks_changed.emit()
         self.current_index = -1
         self.cancel_requested = False
         self.batch_started.emit(len(self.tasks))


### PR DESCRIPTION
## Summary
- rename Preview tab to Edit Batch Commands and list all batch commands
- keep command list synced with queue ordering and allow inline edits
- fix edit checkboxes so multiple tasks can be flagged

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/ui/widgets/profile_editor.py)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc9822edc832589f2825697f41e39