### PR TITLE
fix(ui): streamline command edit refresh

### DIFF
--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -191,8 +191,9 @@ class MainWindow(QMainWindow):
         else:
             self.log_controls.setDirection(QBoxLayout.LeftToRight)
 
-    def _refresh_command_edit(self) -> None:
-        cmds = self.batch_panel.all_command_previews()
+    def _refresh_command_edit(self, cmds: list[str] | None = None) -> None:
+        if cmds is None:
+            cmds = self.batch_panel.all_command_previews()
         self.command_edit.blockSignals(True)
         self.command_edit.setRowCount(len(cmds))
         for i, cmd in enumerate(cmds):
@@ -228,41 +229,8 @@ class MainWindow(QMainWindow):
             self.command_edit.blockSignals(True)
             item.setText(self.batch_panel.command_preview(row))
             self.command_edit.blockSignals(False)
-        self.command_edit.blockSignals(True)
-        self.command_edit.setRowCount(len(cmds))
-        self.command_edit.setVerticalHeaderLabels(
-            [str(i + 1) for i in range(len(cmds))]
-        )
-        for i, cmd in enumerate(cmds):
-            icon_text = "✎" if self.batch_panel.task_is_editable(i) else "🔒"
-            icon_item = QTableWidgetItem(icon_text)
-            icon_item.setFlags(Qt.ItemIsEnabled)
-            icon_item.setTextAlignment(Qt.AlignCenter)
-            cmd_item = QTableWidgetItem(cmd)
-            if self.batch_panel.task_is_editable(i):
-                cmd_item.setFlags(
-                    Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
-                )
-            else:
-                cmd_item.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
-                cmd_item.setForeground(Qt.gray)
-            self.command_edit.setItem(i, 0, icon_item)
-            self.command_edit.setItem(i, 1, cmd_item)
-        self.command_edit.blockSignals(False)
-
-    def _command_preview_changed(self, item: QTableWidgetItem) -> None:
-        row = item.row()
-        col = item.column()
-        if col != 1:
-            return
-        cmd = item.text().strip()
-        if self.batch_panel.task_is_editable(row):
-            self.batch_panel.set_command_override(row, cmd, emit=False)
-        else:
-            self.command_edit.blockSignals(True)
-            item.setText(self.batch_panel.command_preview(row))
-            self.command_edit.blockSignals(False)
-        self.batch_panel.tasks_changed.emit()
+        cmds = self.batch_panel.all_command_previews()
+        self._refresh_command_edit(cmds)
 
     # ----- Menus -----
     def _build_menu(self) -> None:


### PR DESCRIPTION
## Summary
- remove duplicate command preview handler
- refresh batch command table through `_refresh_command_edit`
- compute command previews once per edit

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat aegis/app.py, aegis/ui/widgets/profile_editor.py)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aegis')*


------
https://chatgpt.com/codex/tasks/task_e_68bbecd7a5988325a2e5fda6703f5955