### PR TITLE
chore(ci,docs): split cross-platform checks and expand guidance

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,8 +19,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Verify PySide6 import
+        run: python -c "import PySide6"
       - name: Run ruff
         run: ruff check .
       - name: Run black

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -19,11 +19,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Verify installation
         run: python -m pip check
-      - name: Check PySide6 import
+      - name: Verify PySide6 import
         run: python -c "import PySide6"
       - name: Run mypy
         run: mypy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Verify PySide6 import
+        run: python -c "import PySide6"
       - name: Run tests
         run: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,19 @@
 - Run `ruff check .`, `black --check .`, `mypy`, and `PYTHONPATH=$PWD pytest` before pushing.
 - Refer to [docs/architecture.md](docs/architecture.md) for layout and extension points when adding new tools.
 
+## UI standards
+- Widget classes use PascalCase and end with `Widget`. Instances set a snake_case
+  `objectName` with suffixes such as `_btn`, `_dock`, or `_log`.
+- Buttons use verb-first labels (for example, `Build Paks`, `Run Tests`). Every
+  action shows a copyable command preview that matches the exact `argv` passed to
+  `subprocess.Popen`.
+- Panels are implemented as `QDockWidget` instances with
+  `setAllowedAreas(Qt.AllDockWidgetAreas)` and features set to
+  `DockWidgetMovable | DockWidgetFloatable`.
+- Themes live under `aegis/ui/themes/*.qss`; target widgets by `objectName` and
+  persist the selected theme with `QSettings`.
+- See `CODING_STANDARDS.md` for required type hints and subprocess policies.
+
 ## Pull requests
 - Target `dev` unless fixing a critical issue on `main`.
 - Describe manual test steps and results.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,17 @@ See `CODING_STANDARDS.md` for naming conventions and guardrails.
 
 ## PyInstaller builds
 
-The [release workflow](.github/workflows/release.yml) packages the app with
-PyInstaller. The same command can be run locally to produce standalone
-executables in the `dist/` folder.
+The [release workflow](.github/workflows/release.yml) uses PyInstaller to
+produce standalone binaries. The same steps can be executed locally:
 
 ### macOS
 
-Install Xcode command line tools and ensure Python 3.11 is available:
+**Prerequisites**
+
+- Xcode Command Line Tools
+- Python 3.11+
+
+**Build**
 
 ```bash
 xcode-select --install  # first-time setup
@@ -90,7 +94,13 @@ pyinstaller -F -n Aegis --add-data "aegis/ui/themes:ui/themes" aegis/app.py
 
 ### Linux (Debian/Ubuntu)
 
-Install build tools and Qt libraries required by PySide6:
+**Prerequisites**
+
+- `build-essential`
+- `libglib2.0-0` `libglu1-mesa` `libxkbcommon-x11-0` `libxcb-cursor0`
+- Python 3.11+
+
+**Build**
 
 ```bash
 sudo apt-get update
@@ -99,7 +109,7 @@ pip install -r requirements.txt pyinstaller
 pyinstaller -F -n Aegis --add-data "aegis/ui/themes:ui/themes" aegis/app.py
 ```
 
-The generated binary is placed in `dist/`.
+Artifacts are written to the `dist/` directory.
 
 ## CI/CD
 
@@ -131,8 +141,9 @@ runner.start(
 )
 # runner.cancel()  # terminate early
 ```
-
-See [docs/architecture.md](docs/architecture.md) for extension points and layout details.
+See [docs/architecture.md](docs/architecture.md) for extension points and
+layout details, and consult the docstrings of `TaskRunner.start` and
+`TaskRunner.cancel` for full API semantics.
 
 ## Troubleshooting
 

--- a/aegis/core/task_runner.py
+++ b/aegis/core/task_runner.py
@@ -51,6 +51,11 @@ class TaskRunner(QObject):
             Emitted immediately after the subprocess is spawned.
         finished
             Emitted with the exit code after the watcher thread completes.
+
+        Raises
+        ------
+        RuntimeError
+            If another task is already running.
         """
         if self._proc:
             raise RuntimeError("A task is already running")
@@ -91,8 +96,9 @@ class TaskRunner(QObject):
         """Terminate the running subprocess, if any.
 
         ``terminate()`` sends ``SIGTERM`` and returns immediately; the watcher
-        thread created by :meth:`start` will still emit :pyattr:`finished` once
-        the process exits.
+        thread created by :meth:`start` still emits :pyattr:`finished` when the
+        process exits. Calling :meth:`cancel` when no task is active is a
+        no-op.
         """
         if self._proc:
             self._proc.terminate()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,44 +1,89 @@
 # Architecture
 
-This project wraps Unreal Engine command‑line tools in a PySide6 desktop GUI. The layout keeps core services, thin CLI modules, and UI widgets separate so new tools can plug in cleanly.
+This project wraps Unreal Engine command‑line tools in a PySide6 desktop GUI.
+The repository is organized so core services, thin CLI modules, and UI widgets
+stay decoupled and easy to extend.
+
+## Repository layout
+
+- `aegis/app.py` – application entry point
+- `aegis/core/` – shared services such as settings management and the
+  subprocess task runner
+- `aegis/modules/` – wrappers for individual Unreal command‑line tools
+- `aegis/ui/` – Qt widgets, pages, and themes
+- `docs/` – developer documentation
+- `tests/` – unit and functional tests
 
 ## Core
-- `aegis/app.py` – application entry point.
-- `aegis/core` – infrastructure such as:
-  - `task_runner.py` streaming subprocess output without blocking the UI.
-  - `settings.py` and `profile.py` for persisted preferences and profiles.
-  - helpers like `app_preferences.py`, `key_bindings.py`, and `log_colors.py`.
 
-The core provides shared services and utilities used by all modules and widgets.
+The core package provides reusable building blocks:
+
+- `task_runner.py` – streams subprocess output on background threads so the UI
+  remains responsive. See the `start` and `cancel` docstrings for API details.
+- `settings.py` and `profile.py` – persist application preferences and project
+  profiles.
+- Helpers like `app_preferences.py`, `key_bindings.py`, and `log_colors.py`.
+
+These modules avoid GUI dependencies and can be imported by both CLI wrappers
+and widgets.
 
 ## Modules
-`aegis/modules` contains thin wrappers around individual CLI tools (e.g. `uaft.py`, `uat.py`, `ubt.py`). Each module focuses on:
-- Building exact argv lists without using `shell=True`.
-- Parsing line‑based output where helpful.
-- Leaving execution to `TaskRunner` so stdout/stderr stream into the Live Log and exit codes surface to the user.
+
+`aegis/modules` contains thin adapters around command‑line tools such as
+`uaft.py`, `uat.py`, and `ubt.py`.
+
+Responsibilities:
+
+- Build exact argv lists without using `shell=True`.
+- Parse line‑based output where helpful.
+- Delegate execution to `TaskRunner` so stdout/stderr stream into the Live Log
+  and exit codes surface to the user.
 
 ### Extension points
+
 To add a new CLI integration:
-1. Create a module in `aegis/modules` that exposes functions or classes to build argv lists and parse output.
+
+1. Create a module under `aegis/modules` that exposes functions or classes to
+   build argv lists and parse output.
 2. Use `TaskRunner` to execute commands from the UI.
 3. Avoid blocking calls and redact secrets in logs.
 
 ## UI layout
-`aegis/ui` hosts all Qt code:
-- `main_window.py` sets up the `QMainWindow` with movable/floatable/tabbable `QDockWidget` panes.
-- `widgets/` contains dock widgets like `log_panel.py`, `batch_builder_panel.py`, and `uaft_panel.py`.
-- `themes/` holds QSS files (`dark.qss`, `light.qss`, `high_contrast.qss`) applied via QSettings. A “Reset Layout” and “Load Theme…” action live in the main menu.
 
-UI components present verbs as buttons, show the exact command preview, and stream logs while keeping the GUI thread responsive.
+All Qt code lives under `aegis/ui`:
+
+- `main_window.py` configures the `QMainWindow` and dock widgets.
+- `pages/` groups high‑level views.
+- `widgets/` holds dockable panels such as `log_panel.py`,
+  `batch_builder_panel.py`, and `uaft_panel.py`.
+- `themes/` contains QSS files (`dark.qss`, `light.qss`, `high_contrast.qss`).
+
+UI elements follow these conventions:
+
+- Widgets have verb‑first buttons and expose an exact command preview.
+- Each dock uses `setAllowedAreas(Qt.AllDockWidgetAreas)` and enables the
+  `DockWidgetMovable | DockWidgetFloatable` features.
+- Themes are loaded via `QSettings` with a "Reset Layout" and "Load Theme…"
+  action available in the main menu.
 
 ### Adding UI for new tools
-Create a widget under `aegis/ui/widgets` that uses your module's argv builders. Register it with `main_window.py` or the appropriate menu/page so it can be docked and the command preview matches the executed argv.
+
+Create a widget under `aegis/ui/widgets` that uses your module's argv builders.
+Register it with `main_window.py` or the relevant page so the panel can be
+docked and the command preview matches the executed argv.
 
 ## Integrating new CLI tools
-When introducing another command‑line tool:
-1. Detect the tool's executable path (respecting platform differences and EULA safety).
-2. Implement argv builders and output parsers in a new `aegis/modules/<tool>.py` file.
-3. Build a UI panel in `aegis/ui/widgets` that leverages `TaskRunner` for non‑blocking execution and streams logs to the Live Log.
-4. Persist any settings via `settings.py` or `profile.py` and follow existing theming and layout conventions.
 
-This separation ensures one‑click actions with accurate previews, guardrails, and self‑service logs while making it straightforward to grow the toolbelt.
+When introducing another command‑line tool:
+
+1. Detect the tool's executable path (respecting platform differences and EULA
+   safety).
+2. Implement argv builders and output parsers in a new
+   `aegis/modules/<tool>.py` file.
+3. Build a UI panel in `aegis/ui/widgets` that leverages `TaskRunner` for
+   non‑blocking execution and streams logs to the Live Log.
+4. Persist any settings via `settings.py` or `profile.py` and follow existing
+   theming and layout conventions.
+
+This separation ensures one‑click actions with accurate previews, guardrails,
+and self‑service logs while keeping the codebase straightforward to grow.


### PR DESCRIPTION
## Summary
- restore dedicated linting, preflight, and test workflows running on Linux, macOS, and Windows with pip caching and PySide6 checks
- document TaskRunner APIs and flesh out developer guides
- clarify PyInstaller build steps for macOS and Linux

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc02ba07e88325be4bd68bbaa736be