### PR TITLE
fix(core): watch UAFT token file and tighten UI typing

### DIFF
--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -1,3 +1,5 @@
+"""Main application window coordinating panels and global actions."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -5,7 +7,12 @@ import sys
 import subprocess
 
 from PySide6.QtCore import Qt, QUrl
-from PySide6.QtGui import QAction, QDesktopServices, QGuiApplication
+from PySide6.QtGui import (
+    QAction,
+    QDesktopServices,
+    QGuiApplication,
+    QResizeEvent,
+)
 from PySide6.QtWidgets import (
     QMainWindow,
     QMessageBox,
@@ -117,7 +124,8 @@ class MainWindow(QMainWindow, KeyBindingActions, ProfileActions, ThemeActions):
             self._on_system_theme_change
         )
 
-    def resizeEvent(self, event):  # type: ignore[override]
+    def resizeEvent(self, event: QResizeEvent) -> None:  # type: ignore[override]
+        """Ensure log panel width tracks window size."""
         super().resizeEvent(event)
         self.log_panel.reset_size()
 

--- a/aegis/ui/models/__init__.py
+++ b/aegis/ui/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models used by UI widgets."""

--- a/aegis/ui/models/queued_task.py
+++ b/aegis/ui/models/queued_task.py
@@ -1,0 +1,22 @@
+"""Model representing a task queued in the batch builder panel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from PySide6.QtWidgets import QCheckBox, QListWidgetItem, QProgressBar, QWidget
+
+
+@dataclass(slots=True)
+class QueuedTask:
+    """State for a single queued build task."""
+
+    tag: str
+    config: str
+    platform: str
+    item: QListWidgetItem
+    widget: QWidget
+    bar: QProgressBar
+    edit: QCheckBox
+    clean: bool = False
+    cmd_override: str | None = None

--- a/aegis/ui/widgets/batch_builder_panel.py
+++ b/aegis/ui/widgets/batch_builder_panel.py
@@ -1,8 +1,9 @@
+"""Panel for constructing and running batches of build tasks."""
+
 from __future__ import annotations
 
 import sys
 import shlex
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Set
 import shutil
@@ -34,6 +35,7 @@ from aegis.ui.widgets.manual_override_dialog import (
     ManualOverrideDialog,
     BUILD_COOK_RUN_SWITCHES,
 )
+from aegis.ui.models.queued_task import QueuedTask
 
 
 # Include server and editor configurations by default
@@ -68,19 +70,6 @@ EDITABLE_TAGS = {
     "ddc-clean",
     "ddc-rebuild",
 }
-
-
-@dataclass
-class QueuedTask:
-    tag: str
-    config: str
-    platform: str
-    item: QListWidgetItem
-    widget: QWidget
-    bar: QProgressBar
-    edit: QCheckBox
-    clean: bool = False
-    cmd_override: str | None = None
 
 
 class BatchBuilderPanel(QWidget):

--- a/aegis/ui/widgets/uat_override_widget.py
+++ b/aegis/ui/widgets/uat_override_widget.py
@@ -1,0 +1,92 @@
+"""Widget for editing BuildCookRun overrides for UAT."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+    QDialog,
+)
+
+from aegis.ui.widgets.manual_override_dialog import (
+    ManualOverrideDialog,
+    BUILD_COOK_RUN_SWITCHES,
+)
+
+
+class UatOverrideWidget(QGroupBox):
+    """Table and controls for configuring UAT BuildCookRun switches."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__("UAT (BuildCookRun)", parent)
+        layout = QVBoxLayout(self)
+
+        self.table = QTableWidget(0, 2)
+        self.table.setObjectName("uat_override_table")
+        self.table.setHorizontalHeaderLabels(["Switch", "Value"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        row = QHBoxLayout()
+        self.add_btn = QPushButton("Add…")
+        self.add_btn.setObjectName("add_override_btn")
+        self.add_btn.clicked.connect(self._add_override)
+        self.remove_btn = QPushButton("Remove")
+        self.remove_btn.setObjectName("remove_override_btn")
+        self.remove_btn.clicked.connect(self._remove_override)
+        row.addWidget(self.add_btn)
+        row.addWidget(self.remove_btn)
+        layout.addLayout(row)
+
+    def clear(self) -> None:
+        """Remove all overrides."""
+        self.table.setRowCount(0)
+
+    def _add_override(self) -> None:
+        dialog = ManualOverrideDialog(self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        for switch, value in dialog.selected_overrides():
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(switch))
+            self.table.setItem(row, 1, QTableWidgetItem(value))
+            hint = BUILD_COOK_RUN_SWITCHES.get(switch, "")
+            self.table.item(row, 0).setToolTip(hint)
+            self.table.item(row, 1).setToolTip(hint)
+
+    def _remove_override(self) -> None:
+        row = self.table.currentRow()
+        if row != -1:
+            self.table.removeRow(row)
+
+    def manual_args(self) -> list[str]:
+        """Serialize overrides into CLI arguments."""
+        args: list[str] = []
+        for row in range(self.table.rowCount()):
+            key_item = self.table.item(row, 0)
+            if not key_item:
+                continue
+            switch_text = key_item.text().strip()
+            if not switch_text:
+                continue
+            inline_value = ""
+            if "=" in switch_text:
+                switch_part, inline_value = switch_text.split("=", 1)
+            else:
+                switch_part = switch_text
+            switch = "-" + switch_part.lstrip("-")
+            val_item = self.table.item(row, 1)
+            value = val_item.text().strip() if val_item else ""
+            if not value:
+                value = inline_value.strip()
+            if value:
+                args.append(f"{switch}={value}")
+            else:
+                args.append(switch)
+        return args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ addopts = "-ra"
 
 [tool.mypy]
 python_version = "3.11"
-files = ["aegis/modules", "aegis/core/ini_parser.py"]
+files = ["aegis/modules", "aegis/core"]
 ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ ruff==0.12.11
 pytest==8.4.1
 pre-commit==4.0.1
 mypy==1.17.1
+watchdog==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6==6.7.2
+watchdog==4.0.1

--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from aegis.modules.uaft import Uaft
 
 
@@ -15,6 +17,7 @@ SecurityToken={token}
 
 
 def test_security_token_updates(tmp_path: Path) -> None:
+    pytest.importorskip("watchfiles")
     ini = tmp_path / "Config" / "DefaultEngine.ini"
     make_ini(ini, "AAA")
     uaft = Uaft(Path("uaft"), project_dir=tmp_path)

--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 
 from aegis.modules.uaft import Uaft
@@ -20,9 +19,9 @@ def test_security_token_updates(tmp_path: Path) -> None:
     make_ini(ini, "AAA")
     uaft = Uaft(Path("uaft"), project_dir=tmp_path)
     assert uaft.security_token() == "AAA"
-    time.sleep(1.1)
+    uaft._token_updated.clear()
     make_ini(ini, "BBB")
-    time.sleep(1.5)
+    assert uaft._token_updated.wait(timeout=2)
     assert uaft.security_token() == "BBB"
     uaft.stop()
 

--- a/tests/test_uat_override_widget.py
+++ b/tests/test_uat_override_widget.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication, QTableWidgetItem
+
+from aegis.ui.widgets.uat_override_widget import UatOverrideWidget
+
+
+def ensure_app() -> None:
+    if QApplication.instance() is None:
+        QApplication([])
+
+
+def test_manual_args_round_trip() -> None:
+    ensure_app()
+    widget = UatOverrideWidget()
+    widget.table.insertRow(0)
+    widget.table.setItem(0, 0, QTableWidgetItem("cook"))
+    widget.table.setItem(0, 1, QTableWidgetItem("Dir"))
+    assert widget.manual_args() == ["-cook=Dir"]
+
+
+def test_manual_args_inline_value() -> None:
+    ensure_app()
+    widget = UatOverrideWidget()
+    widget.table.insertRow(0)
+    widget.table.setItem(0, 0, QTableWidgetItem("cook=Dir"))
+    assert widget.manual_args() == ["-cook=Dir"]


### PR DESCRIPTION
## Summary
- replace UAFT token polling with an optional filesystem watcher and signaling
- document main window and batch builder panel and extract batch `QueuedTask` model
- expand mypy coverage to `aegis/core`

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc48497a0c83258ee9aa3da2a0572b