### PR TITLE
feat(core): add editable app preferences

### DIFF
--- a/aegis/app.py
+++ b/aegis/app.py
@@ -1,12 +1,16 @@
 from PySide6.QtWidgets import QApplication
 import sys
+from aegis.core.preferences import preferences
 from aegis.ui.main_window import MainWindow
 
 
 def main():
     app = QApplication(sys.argv)
     w = MainWindow()
-    w.show()
+    if preferences.launch_maximized:
+        w.showMaximized()
+    else:
+        w.show()
     sys.exit(app.exec())
 
 

--- a/aegis/core/preferences.py
+++ b/aegis/core/preferences.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+PREFERENCES_FILE = Path(__file__).resolve().parents[2] / "app_preferences" / "app.json"
+
+
+@dataclass
+class AppPreferences:
+    allow_docking: bool = True
+    allow_resizing: bool = True
+    launch_maximized: bool = False
+    width: int = 1280
+    height: int = 800
+
+    @classmethod
+    def load(cls, path: Path = PREFERENCES_FILE) -> "AppPreferences":
+        data: dict[str, object] = {}
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text())
+            except Exception:
+                data = {}
+        prefs = cls()
+        for key, value in data.items():
+            if hasattr(prefs, key):
+                setattr(prefs, key, value)
+        return prefs
+
+    def save(self, path: Path = PREFERENCES_FILE) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2))
+
+
+preferences = AppPreferences.load()

--- a/aegis/ui/menu_builder.py
+++ b/aegis/ui/menu_builder.py
@@ -110,6 +110,28 @@ def build_menu(window: QMainWindow) -> dict[str, QAction]:
     act_reset_keys.triggered.connect(window._reset_key_bindings)
     _populate_keybindings_menu(window, kb_menu)
 
+    prefs_menu = settings_menu.addMenu("Preferences")
+    act_docking = QAction("Allow Docking", window)
+    act_docking.setCheckable(True)
+    act_docking.setChecked(window.prefs.allow_docking)
+    prefs_menu.addAction(act_docking)
+    act_docking.toggled.connect(window._toggle_docking)
+    actions["settings.preferences.docking"] = act_docking
+
+    act_resizing = QAction("Allow Resizing", window)
+    act_resizing.setCheckable(True)
+    act_resizing.setChecked(window.prefs.allow_resizing)
+    prefs_menu.addAction(act_resizing)
+    act_resizing.toggled.connect(window._toggle_resizing)
+    actions["settings.preferences.resizing"] = act_resizing
+
+    act_maximized = QAction("Launch Maximized", window)
+    act_maximized.setCheckable(True)
+    act_maximized.setChecked(window.prefs.launch_maximized)
+    prefs_menu.addAction(act_maximized)
+    act_maximized.toggled.connect(window._toggle_maximized)
+    actions["settings.preferences.launch_maximized"] = act_maximized
+
     help_menu = menu_bar.addMenu("&Help")
     act_help = QAction("Help", window)
     help_menu.addAction(act_help)

--- a/aegis/ui/widgets/log_panel.py
+++ b/aegis/ui/widgets/log_panel.py
@@ -28,7 +28,9 @@ LOG_LABELS = {
 
 
 class LogPanel(QDockWidget):
-    def __init__(self, parent: QMainWindow | None = None) -> None:
+    def __init__(
+        self, parent: QMainWindow | None = None, dockable: bool = True
+    ) -> None:
         super().__init__("Live Log", parent)
         self.setObjectName("dock_live_log")
         self.log_colors = settings.log_colors
@@ -59,15 +61,7 @@ class LogPanel(QDockWidget):
         self.controls = row
         self.setWidget(container)
 
-        self.setFeatures(
-            QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable
-        )
-        self.setAllowedAreas(
-            Qt.BottomDockWidgetArea
-            | Qt.TopDockWidgetArea
-            | Qt.LeftDockWidgetArea
-            | Qt.RightDockWidgetArea
-        )
+        self.set_dockable(dockable)
         self.topLevelChanged.connect(lambda _: self.reset_size())
         self.dockLocationChanged.connect(lambda _: self.reset_size())
         self.reset_size()
@@ -117,3 +111,18 @@ class LogPanel(QDockWidget):
             self.controls.setDirection(QBoxLayout.TopToBottom)
         else:
             self.controls.setDirection(QBoxLayout.LeftToRight)
+
+    def set_dockable(self, dockable: bool) -> None:
+        if dockable:
+            self.setFeatures(
+                QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable
+            )
+            self.setAllowedAreas(
+                Qt.BottomDockWidgetArea
+                | Qt.TopDockWidgetArea
+                | Qt.LeftDockWidgetArea
+                | Qt.RightDockWidgetArea
+            )
+        else:
+            self.setFeatures(QDockWidget.NoDockWidgetFeatures)
+            self.setAllowedAreas(Qt.NoDockWidgetArea)

--- a/app_preferences/app.json
+++ b/app_preferences/app.json
@@ -1,0 +1,7 @@
+{
+  "allow_docking": true,
+  "allow_resizing": true,
+  "launch_maximized": false,
+  "width": 1280,
+  "height": 800
+}

--- a/tests/test_app_preferences_file.py
+++ b/tests/test_app_preferences_file.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from aegis.core.preferences import AppPreferences
+
+
+def test_preferences_load_and_save(tmp_path: Path) -> None:
+    path = tmp_path / "prefs.json"
+    prefs = AppPreferences.load(path)
+    assert prefs.allow_docking is True
+    prefs.allow_docking = False
+    prefs.save(path)
+    loaded = AppPreferences.load(path)
+    assert loaded.allow_docking is False


### PR DESCRIPTION
## Summary
- introduce JSON-backed app preferences
- allow toggling docking, resizing, and launch mode
- persist window geometry and preferences

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc535d194c8325bdf7151e2353e14b