### PR TITLE
feat(ci): dispatch logs to codex

### DIFF
--- a/.github/workflows/codex-loopback.yml
+++ b/.github/workflows/codex-loopback.yml
@@ -1,0 +1,44 @@
+name: codex-loopback
+
+on:
+  workflow_run:
+    workflows: ["tests", "linting"]
+    types:
+      - completed
+
+jobs:
+  loopback:
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch workflow logs
+        id: logs
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const run_id = context.payload.workflow_run.id;
+            const { data } = await github.request(
+              'GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs',
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id,
+              },
+            );
+            return Buffer.from(data).toString('base64');
+      - name: Dispatch to Codex
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'codex_loopback',
+              client_payload: {
+                workflow: context.payload.workflow_run.name,
+                run_id: context.payload.workflow_run.id,
+                commit: context.payload.workflow_run.head_sha,
+                logs_b64: '${{ steps.logs.outputs.result }}',
+              },
+            });

--- a/tests/test_ini_parser.py
+++ b/tests/test_ini_parser.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from aegis.core.ini_parser import get_value, parse_ini
+
+
+def test_parse_ini_operators(tmp_path: Path) -> None:
+    cfg = tmp_path / "Default.ini"
+    cfg.write_text(
+        """
+[Sec]
++Add=A
++Add=A
+Base=1
+.Base=2
+-Base=1
+!Remove
+Remove=42
+Flag
+""",
+        encoding="utf-8",
+    )
+    data = parse_ini(cfg)
+    assert data["Sec"]["Add"] == ["A"]
+    assert data["Sec"]["Base"] == ["2"]
+    assert data["Sec"]["Remove"] == ["42"]
+    assert data["Sec"]["Flag"] == [None]
+    assert get_value(data, "Sec", "Base") == "2"
+    assert get_value(data, "Sec", "Flag") is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtCore import QByteArray, QSettings
+
+from aegis.core.settings import APP, ORG, Settings
+
+
+@pytest.fixture
+def settings_obj(tmp_path: Path) -> Settings:
+    fmt = QSettings.Format.IniFormat
+    scope = QSettings.Scope.UserScope
+    orig = Path(QSettings(fmt, scope, ORG, APP).fileName()).parent
+    QSettings.setPath(fmt, scope, str(tmp_path))
+    s = Settings()
+    yield s
+    QSettings.setPath(fmt, scope, str(orig))
+
+
+def test_theme_and_custom_path(settings_obj: Settings) -> None:
+    s = settings_obj
+    assert s.theme_mode() == "system"
+    s.set_theme_mode("dark")
+    assert s.theme_mode() == "dark"
+    assert s.custom_theme_path() is None
+    s.set_custom_theme_path("theme.qss")
+    assert s.custom_theme_path() == "theme.qss"
+    s.set_custom_theme_path(None)
+    assert s.custom_theme_path() is None
+
+
+def test_geometry_state_and_profile(settings_obj: Settings) -> None:
+    s = settings_obj
+    geom = QByteArray(b"geom")
+    s.save_geometry(geom)
+    assert s.load_geometry() == geom
+    state = QByteArray(b"state")
+    s.save_state(state)
+    assert s.load_state() == state
+    assert s.layout_version() == 0
+    s.set_layout_version(2)
+    assert s.layout_version() == 2
+    assert s.profile_path() is None
+    s.set_profile_path("/tmp/profile")
+    assert s.profile_path() == "/tmp/profile"
+    s.set_profile_path(None)
+    assert s.profile_path() is None


### PR DESCRIPTION
## Summary
- capture logs from failing CI runs
- dispatch logs to Codex for automated fixes

## Testing
- `python -m pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement PySide6==6.7.2)*
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5da1bce08325b4ac171b54be4022