### PR TITLE
chore(ci): enable debug logging and run full os matrix

### DIFF
--- a/.github/workflows/codex-loopback.yml
+++ b/.github/workflows/codex-loopback.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
 jobs:
   loopback:
     if: ${{ github.event.workflow_run.conclusion != 'success' }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: ["main", "dev", "feat/**", "maintenance/**"]
 
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
 jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: ["main", "dev", "feat/**", "maintenance/**"]
 
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
 jobs:
   preflight:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release (PyInstaller)
 on:
   push:
     tags: ["v*.*.*"]
+
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
 jobs:
   win:
     runs-on: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: ["main", "dev", "feat/**", "maintenance/**"]
 
+env:
+  ACTIONS_STEP_DEBUG: true
+  ACTIONS_RUNNER_DEBUG: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     env:
       PYTHONPATH: ${{ github.workspace }}
     steps:


### PR DESCRIPTION
## Summary
- enable debug logging for all GitHub Actions workflows
- run matrix jobs in Windows→Linux→macOS order
- keep matrix jobs running across all OSs by disabling fail-fast

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc68bdc9f88325a2c0e0f7432a54a7