### PR TITLE
feat(uaft): extract token watcher helper

### DIFF
--- a/aegis/modules/uaft.py
+++ b/aegis/modules/uaft.py
@@ -2,17 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from dataclasses import dataclass, field
-import threading
-from typing import Any
 
-try:  # pragma: no cover - optional dependency
-    from watchdog.events import FileSystemEvent, FileSystemEventHandler
-    from watchdog.observers import Observer
-except Exception:  # pragma: no cover - watchdog may be unavailable
-    Observer = None  # type: ignore[assignment]
-    FileSystemEvent = FileSystemEventHandler = Any  # type: ignore[assignment]
-
-from aegis.core.ini_parser import get_value, parse_ini
+from aegis.modules.uaft_token import UaftTokenWatcher
 
 
 @dataclass
@@ -27,76 +18,20 @@ class Uaft:
 
     exe: Path
     project_dir: Path | None = None
+    token_watcher: UaftTokenWatcher | None = None
     _token: str | None = field(init=False, default=None)
-    _token_mtime: float = field(init=False, default=0.0)
-    _observer: Observer | None = field(init=False, default=None)
-    _watcher: threading.Thread | None = field(init=False, default=None)
-    _stop_evt: threading.Event = field(init=False, default_factory=threading.Event)
-    _token_updated: threading.Event = field(init=False, default_factory=threading.Event)
-
-    def __post_init__(self) -> None:
-        if self.project_dir:
-            self._start_watcher()
-
-    # ----- Security token -----
-    def _config_path(self) -> Path | None:
-        if not self.project_dir:
-            return None
-        for folder in ("Config", "Configs"):
-            cfg = self.project_dir / folder / "DefaultEngine.ini"
-            if cfg.exists():
-                return cfg
-        return self.project_dir / "Config" / "DefaultEngine.ini"
-
-    def _read_token(self) -> str | None:
-        cfg_path = self._config_path()
-        if not cfg_path or not cfg_path.exists():
-            return None
-        cfg = parse_ini(cfg_path)
-        sec = "/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings"
-        token = get_value(cfg, sec, "SecurityToken")
-        if token and "=" in token:
-            token = token.split("=", 1)[1].strip()
-        return token
-
-    def _watch_token(self) -> None:
-        while not self._stop_evt.wait(timeout=1):
-            cfg_path = self._config_path()
-            if cfg_path and cfg_path.exists():
-                mtime = cfg_path.stat().st_mtime
-                if mtime != self._token_mtime:
-                    self._token_mtime = mtime
-                    self._on_config_change()
-
-    def _start_watcher(self) -> None:
-        self._token = self._read_token()
-        cfg_path = self._config_path()
-        if cfg_path and cfg_path.exists():
-            self._token_mtime = cfg_path.stat().st_mtime
-            if Observer:
-                handler = _ConfigHandler(self)
-                self._observer = Observer()
-                self._observer.schedule(handler, str(cfg_path.parent), recursive=False)
-                self._observer.start()
-            else:
-                self._watcher = threading.Thread(target=self._watch_token, daemon=True)
-                self._watcher.start()
-
-    def _on_config_change(self) -> None:
-        self._token = self._read_token()
-        self._token_updated.set()
 
     def stop(self) -> None:
-        self._stop_evt.set()
-        if self._observer and self._observer.is_alive():
-            self._observer.stop()
-            self._observer.join(timeout=1)
-        if self._watcher and self._watcher.is_alive():
-            self._watcher.join(timeout=1)
+        if self.token_watcher:
+            self.token_watcher.stop()
 
+    # ----- Security token -----
     def security_token(self) -> str | None:
-        if not self._token:
-            self._token = self._read_token()
+        if self.token_watcher:
+            return self.token_watcher.security_token()
+        if self._token is None and self.project_dir:
+            watcher = UaftTokenWatcher(self.project_dir, watch=False)
+            self._token = watcher.security_token()
         return self._token
 
     # ----- Arg builders -----
@@ -201,15 +136,3 @@ class Uaft:
             args += ["-k", token]
         args += ["pull", remote_file, str(local_dir)]
         return args
-
-
-class _ConfigHandler(FileSystemEventHandler):
-    """Watchdog handler to reload UAFT token on config changes."""
-
-    def __init__(self, uaft: Uaft) -> None:
-        self.uaft = uaft
-
-    def on_modified(self, event: FileSystemEvent) -> None:  # pragma: no cover - simple
-        cfg_path = self.uaft._config_path()
-        if cfg_path and Path(event.src_path) == cfg_path:
-            self.uaft._on_config_change()

--- a/aegis/modules/uaft_token.py
+++ b/aegis/modules/uaft_token.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import threading
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+except Exception:  # pragma: no cover - watchdog may be unavailable
+    Observer = None  # type: ignore[assignment]
+    FileSystemEvent = FileSystemEventHandler = Any  # type: ignore[assignment]
+
+from aegis.core.ini_parser import get_value, parse_ini
+
+
+@dataclass
+class UaftTokenWatcher:
+    """Monitor a UAFT project for token changes."""
+
+    project_dir: Path
+    watch: bool = True
+    _token: str | None = field(init=False, default=None)
+    _token_mtime: float = field(init=False, default=0.0)
+    _observer: Observer | None = field(init=False, default=None)
+    _watcher: threading.Thread | None = field(init=False, default=None)
+    _stop_evt: threading.Event = field(init=False, default_factory=threading.Event)
+    token_updated: threading.Event = field(init=False, default_factory=threading.Event)
+
+    def __post_init__(self) -> None:
+        self._token = self._read_token()
+        if self.watch:
+            cfg_path = self._config_path()
+            if cfg_path and cfg_path.exists():
+                self._token_mtime = cfg_path.stat().st_mtime
+                if Observer:
+                    handler = _ConfigHandler(self)
+                    self._observer = Observer()
+                    self._observer.schedule(
+                        handler, str(cfg_path.parent), recursive=False
+                    )
+                    self._observer.start()
+                else:
+                    self._watcher = threading.Thread(
+                        target=self._watch_token, daemon=True
+                    )
+                    self._watcher.start()
+
+    def _config_path(self) -> Path | None:
+        for folder in ("Config", "Configs"):
+            cfg = self.project_dir / folder / "DefaultEngine.ini"
+            if cfg.exists():
+                return cfg
+        return self.project_dir / "Config" / "DefaultEngine.ini"
+
+    def _read_token(self) -> str | None:
+        cfg_path = self._config_path()
+        if not cfg_path or not cfg_path.exists():
+            return None
+        cfg = parse_ini(cfg_path)
+        sec = "/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings"
+        token = get_value(cfg, sec, "SecurityToken")
+        if token and "=" in token:
+            token = token.split("=", 1)[1].strip()
+        return token
+
+    def _watch_token(self) -> None:
+        while not self._stop_evt.wait(timeout=1):
+            cfg_path = self._config_path()
+            if cfg_path and cfg_path.exists():
+                mtime = cfg_path.stat().st_mtime
+                if mtime != self._token_mtime:
+                    self._token_mtime = mtime
+                    self._on_config_change()
+
+    def _on_config_change(self) -> None:
+        self._token = self._read_token()
+        self.token_updated.set()
+
+    def stop(self) -> None:
+        self._stop_evt.set()
+        if self._observer and self._observer.is_alive():
+            self._observer.stop()
+            self._observer.join(timeout=1)
+        if self._watcher and self._watcher.is_alive():
+            self._watcher.join(timeout=1)
+
+    def security_token(self) -> str | None:
+        if not self._token:
+            self._token = self._read_token()
+        return self._token
+
+
+class _ConfigHandler(FileSystemEventHandler):
+    """Watchdog handler to reload UAFT token on config changes."""
+
+    def __init__(self, watcher: UaftTokenWatcher) -> None:
+        self.watcher = watcher
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # pragma: no cover - simple
+        cfg_path = self.watcher._config_path()
+        if cfg_path and Path(event.src_path) == cfg_path:
+            self.watcher._on_config_change()

--- a/tests/test_uaft.py
+++ b/tests/test_uaft.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from aegis.modules.uaft import Uaft
 
 
@@ -14,19 +12,6 @@ SecurityToken={token}
 """,
         encoding="utf-8",
     )
-
-
-@pytest.mark.xfail(reason="watchdog event not firing in CI")
-def test_security_token_updates(tmp_path: Path) -> None:
-    ini = tmp_path / "Config" / "DefaultEngine.ini"
-    make_ini(ini, "AAA")
-    uaft = Uaft(Path("uaft"), project_dir=tmp_path)
-    assert uaft.security_token() == "AAA"
-    uaft._token_updated.clear()
-    make_ini(ini, "BBB")
-    assert uaft._token_updated.wait(timeout=2)
-    assert uaft.security_token() == "BBB"
-    uaft.stop()
 
 
 def test_security_token_after_delimiter(tmp_path: Path) -> None:

--- a/tests/test_uaft_token.py
+++ b/tests/test_uaft_token.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import time
+
+import pytest
+
+from aegis.modules.uaft_token import UaftTokenWatcher
+
+
+def make_ini(path: Path, token: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""
+[/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
+SecurityToken={token}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_token_refresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ini = tmp_path / "Config" / "DefaultEngine.ini"
+    make_ini(ini, "AAA")
+    monkeypatch.setattr("aegis.modules.uaft_token.Observer", None)
+    watcher = UaftTokenWatcher(tmp_path)
+    assert watcher.security_token() == "AAA"
+    watcher.token_updated.clear()
+    time.sleep(1.1)
+    make_ini(ini, "BBB")
+    assert watcher.token_updated.wait(timeout=5)
+    assert watcher.security_token() == "BBB"
+    watcher.stop()


### PR DESCRIPTION
## Summary
- move UAFT token config parsing and watching to UaftTokenWatcher helper
- allow Uaft to optionally receive a watcher instead of starting threads
- test token refresh through UaftTokenWatcher

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf60396348325ab0b59d69c4bbe92