### PR TITLE
chore(typing): annotate top-level functions

### DIFF
--- a/aegis/app.py
+++ b/aegis/app.py
@@ -1,10 +1,12 @@
 from PySide6.QtWidgets import QApplication
 import sys
+
 from aegis.core.preferences import preferences
 from aegis.ui.main_window import MainWindow
 
 
-def main():
+def main() -> None:
+    """Launch the Aegis Toolbelt application."""
     app = QApplication(sys.argv)
     w = MainWindow()
     if preferences.launch_maximized:

--- a/tests/test_batch_defaults.py
+++ b/tests/test_batch_defaults.py
@@ -5,10 +5,10 @@ pytest.importorskip("PySide6")
 from aegis.ui.widgets.batch_builder_panel import DEFAULT_CONFIGS, DEFAULT_PLATFORMS
 
 
-def test_default_configs_include_server_and_editor():
+def test_default_configs_include_server_and_editor() -> None:
     assert "DevelopmentServer" in DEFAULT_CONFIGS
     assert "DevelopmentEditor" in DEFAULT_CONFIGS
 
 
-def test_default_platforms_include_mac():
+def test_default_platforms_include_mac() -> None:
     assert "Mac" in DEFAULT_PLATFORMS

--- a/tests/test_command_editor.py
+++ b/tests/test_command_editor.py
@@ -3,6 +3,7 @@
 import pytest
 
 pytest.importorskip("PySide6")
+from pytestqt.qtbot import QtBot
 
 from PySide6.QtCore import QObject, Signal
 
@@ -33,7 +34,7 @@ class DummyBatch(QObject):
         return self.cmds[row]
 
 
-def test_refresh_populates_rows(qtbot) -> None:
+def test_refresh_populates_rows(qtbot: QtBot) -> None:
     batch = DummyBatch()
     editor = CommandEditor(batch)  # type: ignore[arg-type]
     qtbot.addWidget(editor)

--- a/tests/test_profile_custom_fields.py
+++ b/tests/test_profile_custom_fields.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from aegis.core.profile import Profile
 
 
-def test_profile_roundtrip(tmp_path):
+def test_profile_roundtrip(tmp_path: Path) -> None:
     path = tmp_path / "profile.json"
     prof = Profile(
         engine_root=Path("/Engine"),


### PR DESCRIPTION
## Summary
- declare `main()` with type hints and docstring
- add explicit annotations for test helpers and cases

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf60887c4832594787beb8552c9a0