### PR TITLE
fix(task_runner): handle spawn errors

### DIFF
--- a/aegis/core/task_runner.py
+++ b/aegis/core/task_runner.py
@@ -60,13 +60,21 @@ class TaskRunner(QObject):
         if self._proc:
             raise RuntimeError("A task is already running")
 
-        self._proc = subprocess.Popen(
-            argv,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            shell=False,
-        )
+        try:
+            self._proc = subprocess.Popen(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                shell=False,
+            )
+        except OSError as exc:
+            code = exc.errno or 1
+            on_stderr(str(exc))
+            on_exit(code)
+            self.finished.emit(code)
+            return
+
         self.started.emit()
 
         def pump(stream, cb):

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import errno
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtWidgets import QApplication
+from PySide6.QtTest import QSignalSpy
+
+from aegis.core.task_runner import TaskRunner
+
+
+@pytest.fixture(scope="module")
+def app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_invalid_executable_path_emits_error(app: QApplication, tmp_path) -> None:
+    runner = TaskRunner()
+    spy = QSignalSpy(runner.finished)
+    stderr: list[str] = []
+    codes: list[int] = []
+
+    runner.start(
+        [str(tmp_path / "missing.exe")], lambda _: None, stderr.append, codes.append
+    )
+
+    assert codes == [errno.ENOENT]
+    assert spy.count() == 1
+    assert spy.takeFirst()[0] == errno.ENOENT
+    assert "missing.exe" in stderr[0]


### PR DESCRIPTION
## Summary
- guard TaskRunner.start against OSError when spawning processes
- capture spawn failures via stderr and exit code
- test missing executable path handling

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf614f4308325acea0a8d2b50386e