### PR TITLE
fix(core): warn on corrupted preference files

### DIFF
--- a/aegis/core/preferences.py
+++ b/aegis/core/preferences.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
+import logging
 from pathlib import Path
 
 PREFERENCES_FILE = Path(__file__).resolve().parents[2] / "app_preferences" / "app.json"
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -23,7 +27,8 @@ class AppPreferences:
         if path.is_file():
             try:
                 data = json.loads(path.read_text())
-            except Exception:
+            except json.JSONDecodeError as err:
+                logger.warning("Failed to load preferences from %s: %s", path, err)
                 data = {}
         prefs = cls()
         for key, value in data.items():

--- a/tests/test_app_preferences_file.py
+++ b/tests/test_app_preferences_file.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import logging
+import pytest
 
 from aegis.core.preferences import AppPreferences
 
@@ -11,3 +13,17 @@ def test_preferences_load_and_save(tmp_path: Path) -> None:
     prefs.save(path)
     loaded = AppPreferences.load(path)
     assert loaded.allow_docking is False
+
+
+def test_corrupt_preferences_file_recovers(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    path = tmp_path / "prefs.json"
+    path.write_text("{bad json}")
+    with caplog.at_level(logging.WARNING):
+        prefs = AppPreferences.load(path)
+    assert prefs.allow_docking is True
+    assert any(
+        "Failed to load preferences" in message and str(path) in message
+        for message in caplog.messages
+    )


### PR DESCRIPTION
## Summary
- log corrupted preference files instead of ignoring them
- cover corrupt preference file recovery with a unit test

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf6127eec8325a621375dc98ff189