### PR TITLE
feat(ui): name log panel widgets and centralize metadata

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -33,7 +33,6 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
-        continue-on-error: true
       - name: Verify installation
         run: python -m pip check
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,5 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
-        continue-on-error: true
       - name: Run tests
         run: pytest

--- a/aegis/core/metadata.py
+++ b/aegis/core/metadata.py
@@ -1,0 +1,6 @@
+"""Project-wide metadata constants."""
+
+from __future__ import annotations
+
+FEEDBACK_EMAIL = "rahulguptagamedev@gmail.com"
+REPO_URL = "https://github.com/rahulguptagamedev/Aegis-A-UE-GUI-Toolbelt-for-UE-CLI"

--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -24,6 +24,7 @@ from PySide6.QtWidgets import (
 from aegis.core.settings import settings
 from aegis.core.preferences import preferences
 from aegis.core.task_runner import TaskRunner
+from aegis.core.metadata import FEEDBACK_EMAIL, REPO_URL
 from aegis.ui.init_tabs import init_tabs
 from aegis.ui.key_binding_actions import KeyBindingActions
 from aegis.ui.log_color_actions import LogColorActions
@@ -138,19 +139,14 @@ class MainWindow(
             import urllib.parse
 
             query = urllib.parse.urlencode({"subject": subject, "body": body})
-            QDesktopServices.openUrl(
-                QUrl(f"mailto:rahulguptagamedev@gmail.com?{query}")
-            )
+            QDesktopServices.openUrl(QUrl(f"mailto:{FEEDBACK_EMAIL}?{query}"))
 
     def _show_about(self) -> None:
         version = self._get_version()
-        repo_url = (
-            "https://github.com/rahulguptagamedev/Aegis-A-UE-GUI-Toolbelt-for-UE-CLI"
-        )
         info = (
             f"<b>Aegis Toolbelt</b><br>Version: {version}<br>"
             "Author: Rahul Gupta<br>"
-            f"Repository: <a href='{repo_url}'>{repo_url}</a><br>"
+            f"Repository: <a href='{REPO_URL}'>{REPO_URL}</a><br>"
             "A UE GUI toolbelt for Unreal Engine command-line tools.<br>"
             "Licensed under the <a href='https://www.apache.org/licenses/LICENSE-2.0'>Apache 2.0 License</a>."
         )

--- a/aegis/ui/widgets/env_doc.py
+++ b/aegis/ui/widgets/env_doc.py
@@ -8,7 +8,7 @@ import json
 import os
 import shutil
 import subprocess
-import tempfile
+from tempfile import TemporaryDirectory
 import urllib.request
 from pathlib import Path
 from typing import Callable, Optional
@@ -48,6 +48,7 @@ class EnvDocPanel(QWidget):
         self.log = log_cb
         self.profile: Profile | None = None
         self.sdk_path: Path | None = None
+        self._tmp_dir: TemporaryDirectory[str] | None = None
 
         layout = QVBoxLayout(self)
         self.table = QTableWidget(0, 6)
@@ -500,7 +501,8 @@ class EnvDocPanel(QWidget):
             self.log(f"[env] {component} missing", "warning")
 
     def _collect_scripts(self) -> dict[str, Path]:
-        assert self.profile
+        if self.profile is None:
+            raise RuntimeError("profile not loaded")
         root = self.profile.engine_root
         scripts: dict[str, Path] = {}
         android_dir = root / "Extras" / "Android"
@@ -517,7 +519,8 @@ class EnvDocPanel(QWidget):
         try:
             with urllib.request.urlopen(REMOTE_FIX_SCRIPTS_INDEX) as resp:
                 data = json.load(resp)
-            tmp_dir = Path(tempfile.mkdtemp(prefix="aegis_fix_"))
+            self._tmp_dir = TemporaryDirectory(prefix="aegis_fix_")
+            tmp_dir = Path(self._tmp_dir.name)
             for entry in data:
                 name = entry.get("name")
                 url = entry.get("url")
@@ -528,6 +531,9 @@ class EnvDocPanel(QWidget):
                 scripts[name] = dest
         except Exception as exc:  # pragma: no cover - network issues
             self.log(f"[env] {exc}", "error")
+            if self._tmp_dir is not None:
+                self._tmp_dir.cleanup()
+                self._tmp_dir = None
         return scripts
 
     def _run_scripts(self, scripts: list[Path]) -> None:
@@ -563,3 +569,7 @@ class EnvDocPanel(QWidget):
             ps_cmd = f"$p=Start-Process -FilePath '{script}' {args_part}-Verb RunAs -Wait -PassThru; exit $p.ExitCode"
             return ["powershell", "-NoProfile", "-Command", ps_cmd]
         return ["sudo", str(script), *extra_args]
+
+    def __del__(self) -> None:
+        if self._tmp_dir is not None:
+            self._tmp_dir.cleanup()

--- a/aegis/ui/widgets/log_panel.py
+++ b/aegis/ui/widgets/log_panel.py
@@ -1,3 +1,8 @@
+"""Dockable panel displaying streamed log messages.
+
+Refer to ``aegis/ui/AGENTS.md`` for widget naming conventions.
+"""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -37,18 +42,22 @@ class LogPanel(QDockWidget):
 
         self.log = QTextEdit()
         self.log.setReadOnly(True)
+        self.log.setObjectName("log_text_edit")
         self.messages: list[tuple[str, str, str]] = []
 
         self.search = QLineEdit()
         self.search.setPlaceholderText("Search…")
         self.search.textChanged.connect(self.refresh_view)
+        self.search.setObjectName("search_le")
 
         self.filter = QComboBox()
         self.filter.addItems(["All", "Info", "Warning", "Error", "Success"])
         self.filter.currentTextChanged.connect(self.refresh_view)
+        self.filter.setObjectName("filter_cb")
 
         self.clear_btn = QPushButton("Clear")
         self.clear_btn.clicked.connect(self.clear)
+        self.clear_btn.setObjectName("clear_btn")
 
         container = QWidget()
         layout = QVBoxLayout(container)

--- a/tests/test_env_doc_scripts.py
+++ b/tests/test_env_doc_scripts.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+from urllib.error import URLError
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("PySide6")
+from PySide6.QtWidgets import QApplication
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.ui.widgets.env_doc import EnvDocPanel
+
+
+@pytest.fixture(scope="module")
+def app() -> QApplication:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _panel_with_logs() -> tuple[EnvDocPanel, list[tuple[str, str]]]:
+    logs: list[tuple[str, str]] = []
+    panel = EnvDocPanel(TaskRunner(), lambda m, level: logs.append((m, level)))
+    return panel, logs
+
+
+def test_collect_scripts_requires_profile(app: QApplication) -> None:
+    panel, _ = _panel_with_logs()
+    with pytest.raises(RuntimeError, match="profile not loaded"):
+        panel._collect_scripts()
+
+
+def test_collect_scripts_with_profile(app: QApplication, tmp_path: Path) -> None:
+    engine = tmp_path / "eng"
+    (engine / "Extras" / "Android").mkdir(parents=True)
+    local = engine / "Extras" / "Android" / "SetupAndroid.sh"
+    local.write_text("", "utf-8")
+    panel, _ = _panel_with_logs()
+    panel.update_profile(Profile(engine, tmp_path))
+    with patch.object(panel, "_fetch_remote_scripts", return_value={"Remote": local}):
+        scripts = panel._collect_scripts()
+    assert scripts["Android Dependencies"] == local
+    assert "Remote" in scripts
+
+
+def test_fetch_remote_scripts_network_error(app: QApplication) -> None:
+    panel, logs = _panel_with_logs()
+    with (
+        patch("urllib.request.urlopen", side_effect=URLError("boom")),
+        patch("urllib.request.urlretrieve", side_effect=URLError("boom")),
+    ):
+        scripts = panel._fetch_remote_scripts()
+    assert scripts == {}
+    assert any("boom" in msg for msg, _level in logs)
+
+
+def test_fetch_remote_scripts_cleanup(app: QApplication, monkeypatch) -> None:
+    panel, _ = _panel_with_logs()
+    data = [{"name": "fix", "url": "https://example.com/fix.sh"}]
+
+    class DummyResp(io.StringIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *_: DummyResp(json.dumps(data))
+    )
+
+    def fake_urlretrieve(url: str, dest: str, *_args, **_kwargs) -> None:
+        Path(dest).write_text("", "utf-8")
+
+    monkeypatch.setattr("urllib.request.urlretrieve", fake_urlretrieve)
+
+    scripts = panel._fetch_remote_scripts()
+    assert "fix" in scripts
+    tmp_dir = panel._tmp_dir
+    assert tmp_dir is not None and Path(tmp_dir.name).exists()
+    tmp_dir.cleanup()
+    assert not Path(tmp_dir.name).exists()


### PR DESCRIPTION
## Summary
- centralize feedback email and repository URL
- name log panel widgets for QSS styling
- harden EnvDoc script collection and cleanup
- drop `continue-on-error` from dependency installs

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd06e859ec8325bfaa7760c96a8e96