### PR TITLE
fix(ui): clamp and persist window geometry

### DIFF
--- a/aegis/app.py
+++ b/aegis/app.py
@@ -1,3 +1,5 @@
+from PySide6.QtCore import QCoreApplication, Qt
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QApplication
 import sys
 
@@ -7,6 +9,10 @@ from aegis.ui.main_window import MainWindow
 
 def main() -> None:
     """Launch the Aegis Toolbelt application."""
+    QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
+    QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+    )
     app = QApplication(sys.argv)
     w = MainWindow()
     if preferences.launch_maximized:

--- a/aegis/ui/layout_persistence.py
+++ b/aegis/ui/layout_persistence.py
@@ -1,0 +1,55 @@
+"""Persist and clamp window geometry within available screen bounds."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, QRect, QSettings
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import QWidget
+
+
+def clamp_rect_to_available(rect: QRect, widget: QWidget) -> QRect:
+    """Clamp *rect* to the screen's available geometry respecting widget minimums."""
+    win = widget.windowHandle()
+    screen = win.screen() if win else QGuiApplication.primaryScreen()
+    avail = screen.availableGeometry()
+    size = rect.size().boundedTo(avail.size())
+    size.setWidth(max(size.width(), widget.minimumWidth()))
+    size.setHeight(max(size.height(), widget.minimumHeight()))
+    x = max(avail.left(), min(rect.left(), avail.right() - size.width()))
+    y = max(avail.top(), min(rect.top(), avail.bottom() - size.height()))
+    return QRect(QPoint(x, y), size)
+
+
+def restore_window_geometry(
+    window: QWidget, settings: QSettings, key_prefix: str = "main"
+) -> None:
+    """Restore saved geometry/state and clamp to the current screen."""
+    geom = settings.value(f"{key_prefix}/geometry", None, type=bytes)
+    state = settings.value(f"{key_prefix}/state", None, type=bytes)
+    if geom:
+        window.restoreGeometry(geom)
+    if state:
+        window.restoreState(state)
+    clamped = clamp_rect_to_available(window.frameGeometry(), window)
+    window.setGeometry(clamped)
+
+
+def save_window_geometry(
+    window: QWidget, settings: QSettings, key_prefix: str = "main"
+) -> None:
+    """Persist window geometry and state to *settings*."""
+    settings.setValue(f"{key_prefix}/geometry", window.saveGeometry())
+    settings.setValue(f"{key_prefix}/state", window.saveState())
+
+
+def debug_minimums(window: QWidget) -> None:
+    """Print minimum sizes for *window* and its children for debugging."""
+    print("Window minimum:", window.minimumSize())
+    for w in window.findChildren(QWidget):
+        if w.minimumWidth() > 0 or w.minimumHeight() > 0:
+            print(
+                w.objectName(),
+                w.metaObject().className(),
+                w.minimumWidth(),
+                w.minimumHeight(),
+            )

--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -34,6 +34,11 @@ from aegis.ui.widgets.feedback_dialog import FeedbackDialog
 from aegis.ui.widgets.help_dialog import HelpDialog
 from aegis.ui.widgets.log_panel import LogPanel
 from aegis.ui.menu_builder import build_menu
+from aegis.ui.layout_persistence import (
+    clamp_rect_to_available,
+    restore_window_geometry,
+    save_window_geometry,
+)
 
 
 class MainWindow(
@@ -88,12 +93,18 @@ class MainWindow(
         self.profile = None
         self.actions: dict[str, QAction] = build_menu(self)
         self._apply_key_bindings()
-        self._apply_saved_layout()
+        restore_window_geometry(self, settings.s, key_prefix="ui")
         self._apply_saved_theme()
         self._load_last_profile()
         QGuiApplication.styleHints().colorSchemeChanged.connect(
             self._on_system_theme_change
         )
+        if self.windowHandle():
+            self.windowHandle().screenChanged.connect(
+                lambda _: self.setGeometry(
+                    clamp_rect_to_available(self.frameGeometry(), self)
+                )
+            )
 
     def resizeEvent(self, event: QResizeEvent) -> None:  # type: ignore[override]
         """Ensure log panel width tracks window size."""
@@ -207,8 +218,7 @@ class MainWindow(
             self.prefs.width = self.width()
             self.prefs.height = self.height()
         self.prefs.save()
-        settings.save_geometry(self.saveGeometry())
-        settings.save_state(self.saveState())
+        save_window_geometry(self, settings.s, key_prefix="ui")
         super().closeEvent(ev)
 
     def _toggle_docking(self, checked: bool) -> None:

--- a/tests/test_layout_persistence.py
+++ b/tests/test_layout_persistence.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PySide6.QtCore import QRect, QSettings
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import QApplication, QWidget
+
+from aegis.ui.layout_persistence import (
+    clamp_rect_to_available,
+    restore_window_geometry,
+    save_window_geometry,
+)
+
+
+@pytest.fixture()
+def app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_clamp_rect_to_available(app: QApplication) -> None:
+    w = QWidget()
+    avail = QGuiApplication.primaryScreen().availableGeometry()
+    rect = QRect(
+        avail.right() - 10, avail.bottom() - 10, avail.width() * 2, avail.height() * 2
+    )
+    clamped = clamp_rect_to_available(rect, w)
+    assert clamped.left() >= avail.left()
+    assert clamped.top() >= avail.top()
+    assert clamped.right() <= avail.right()
+    assert clamped.bottom() <= avail.bottom()
+
+
+def test_save_restore_geometry(tmp_path: Path, app: QApplication) -> None:
+    w = QWidget()
+    w.resize(800, 600)
+    w.move(50, 50)
+    s = QSettings(str(tmp_path / "geom.ini"), QSettings.IniFormat)
+    save_window_geometry(w, s, key_prefix="ui")
+    # Change size and position
+    w.resize(200, 200)
+    w.move(0, 0)
+    restore_window_geometry(w, s, key_prefix="ui")
+    avail = QGuiApplication.primaryScreen().availableGeometry()
+    assert w.width() <= avail.width()
+    assert w.height() <= avail.height()


### PR DESCRIPTION
## Summary
- add layout_persistence helper for clamped save/restore
- restore and save geometry in MainWindow with screen-change clamping
- configure high-DPI scaling before QApplication

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest` *(fails: No module named 'PySide6')*


------
https://chatgpt.com/codex/tasks/task_e_68bd10c50e388325a562a2026596d59c