### PR TITLE
feat(ui): add Pak / IoStore panel

### DIFF
--- a/aegis/ui/init_tabs.py
+++ b/aegis/ui/init_tabs.py
@@ -13,6 +13,7 @@ from aegis.ui.widgets.command_editor import CommandEditor
 from aegis.ui.widgets.env_doc import EnvDocPanel
 from aegis.ui.widgets.profile_info_bar import ProfileInfoBar
 from aegis.ui.widgets.uaft_panel import UaftPanel
+from aegis.ui.widgets.pak_iostore_panel import PakIoStorePanel
 
 
 @dataclass
@@ -54,7 +55,7 @@ def init_tabs(runner: TaskRunner, log_cb: Callable[[str, str], None]) -> TabSetu
     tabs.addTab(env_container, "EnvDoc")
     tabs.addTab(build_container, "Build")
     tabs.addTab(QTextEdit("Commandlets (stub)"), "Commandlets")
-    tabs.addTab(QTextEdit("Pak/IoStore (stub)"), "Pak/IoStore")
+    tabs.addTab(PakIoStorePanel(), "Pak / IoStore")
     tabs.addTab(uaft_container, "Devices / UAFT")
     tabs.addTab(QTextEdit("Tests (stub)"), "Tests")
     tabs.addTab(QTextEdit("Trace Ops (stub)"), "Trace Ops")

--- a/aegis/ui/widgets/__init__.py
+++ b/aegis/ui/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""Widget exports."""
+
+from .pak_iostore_panel import PakIoStorePanel
+
+__all__ = ["PakIoStorePanel"]

--- a/aegis/ui/widgets/pak_iostore/__init__.py
+++ b/aegis/ui/widgets/pak_iostore/__init__.py
@@ -1,8 +1,12 @@
 from .panel import PakIoStorePanel
+from .single_tab import SingleFileTab
+from .directory_tab import DirectoryTab
 from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
 
 __all__ = [
     "PakIoStorePanel",
+    "SingleFileTab",
+    "DirectoryTab",
     "build_iostore_cmd",
     "build_unrealpak_cmd",
     "dest_for",

--- a/aegis/ui/widgets/pak_iostore/__init__.py
+++ b/aegis/ui/widgets/pak_iostore/__init__.py
@@ -1,0 +1,9 @@
+from .panel import PakIoStorePanel
+from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+
+__all__ = [
+    "PakIoStorePanel",
+    "build_iostore_cmd",
+    "build_unrealpak_cmd",
+    "dest_for",
+]

--- a/aegis/ui/widgets/pak_iostore/directory_tab.py
+++ b/aegis/ui/widgets/pak_iostore/directory_tab.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QCheckBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+from .worker import PakWorker, Task
+
+
+class DirectoryTab(QWidget):
+    """Sub-widget handling directory scans and batch operations."""
+
+    def __init__(
+        self, log_cb: Callable[[str], None], parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self._log = log_cb
+        self.worker: Optional[PakWorker] = None
+        self._get_unrealpak: Callable[[], str] = lambda: ""
+        self._get_iostore: Callable[[], str] = lambda: ""
+        self._get_filter: Callable[[], str] = lambda: ""
+        self._busy = False
+        self._eula = False
+        self._build_ui()
+        self._connect()
+
+    # ------------------------------------------------------------------
+    def set_worker(
+        self,
+        worker: PakWorker,
+        unrealpak: Callable[[], str],
+        iostore: Callable[[], str],
+        filt: Callable[[], str],
+    ) -> None:
+        self.worker = worker
+        self._get_unrealpak = unrealpak
+        self._get_iostore = iostore
+        self._get_filter = filt
+
+    # ----- UI ---------------------------------------------------------
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        dir_row = QHBoxLayout()
+        self.dir_root = QLineEdit()
+        self.dir_browse = QPushButton("Browse")
+        dir_row.addWidget(QLabel("Root directory"))
+        dir_row.addWidget(self.dir_root, 1)
+        dir_row.addWidget(self.dir_browse)
+        layout.addLayout(dir_row)
+
+        self.dir_recurse = QCheckBox("Recurse subdirectories")
+        self.dir_recurse.setChecked(True)
+        self.dir_unzip = QCheckBox("Also unzip .obb/.aab files")
+        self.dir_unzip.setChecked(True)
+        self.dir_unzip_extract = QCheckBox(
+            "After unzip, also extract any .pak found inside"
+        )
+        self.dir_unzip_extract.setChecked(True)
+        layout.addWidget(self.dir_recurse)
+        layout.addWidget(self.dir_unzip)
+        layout.addWidget(self.dir_unzip_extract)
+
+        self.dir_scan_btn = QPushButton("Scan")
+        layout.addWidget(self.dir_scan_btn)
+
+        self.dir_search = QLineEdit()
+        self.dir_search.setPlaceholderText("Search...")
+        layout.addWidget(self.dir_search)
+
+        self.table = QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["Type", "Path", "Size", "Status"])
+        self.table.setObjectName("pak_table")
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        btn_row = QHBoxLayout()
+        self.dir_extract_sel = QPushButton("Extract Selected")
+        self.dir_extract_all = QPushButton("Extract All")
+        self.dir_validate_sel = QPushButton("Validate Selected")
+        self.dir_validate_all = QPushButton("Validate All")
+        btn_row.addWidget(self.dir_extract_sel)
+        btn_row.addWidget(self.dir_extract_all)
+        btn_row.addWidget(self.dir_validate_sel)
+        btn_row.addWidget(self.dir_validate_all)
+        btn_row.addStretch(1)
+        layout.addLayout(btn_row)
+
+        cmp_box = QGroupBox("Compare Builds")
+        cmp_layout = QVBoxLayout()
+        row_a = QHBoxLayout()
+        self.compare_a = QLineEdit()
+        self.compare_a_browse = QPushButton("Browse")
+        row_a.addWidget(QLabel("Dir A"))
+        row_a.addWidget(self.compare_a, 1)
+        row_a.addWidget(self.compare_a_browse)
+        cmp_layout.addLayout(row_a)
+        row_b = QHBoxLayout()
+        self.compare_b = QLineEdit()
+        self.compare_b_browse = QPushButton("Browse")
+        row_b.addWidget(QLabel("Dir B"))
+        row_b.addWidget(self.compare_b, 1)
+        row_b.addWidget(self.compare_b_browse)
+        cmp_layout.addLayout(row_b)
+        self.compare_btn = QPushButton("Compare Builds")
+        cmp_layout.addWidget(self.compare_btn)
+        cmp_box.setLayout(cmp_layout)
+        layout.addWidget(cmp_box)
+
+        self.status_label = QLabel("Idle")
+        layout.addWidget(self.status_label)
+
+    def _connect(self) -> None:
+        self.dir_browse.clicked.connect(self._pick_dir)
+        self.dir_scan_btn.clicked.connect(self.scan_directory)
+        self.dir_search.textChanged.connect(self._filter_table)
+        self.dir_extract_sel.clicked.connect(lambda: self._extract(True))
+        self.dir_extract_all.clicked.connect(lambda: self._extract(False))
+        self.dir_validate_sel.clicked.connect(lambda: self._validate(True))
+        self.dir_validate_all.clicked.connect(lambda: self._validate(False))
+        self.compare_a_browse.clicked.connect(
+            lambda: self._pick_dir_into(self.compare_a)
+        )
+        self.compare_b_browse.clicked.connect(
+            lambda: self._pick_dir_into(self.compare_b)
+        )
+        self.compare_btn.clicked.connect(self._compare_builds)
+        self.table.itemSelectionChanged.connect(self._update_buttons)
+
+    # ----- State ------------------------------------------------------
+    def update_enabled(self, busy: bool, eula: bool) -> None:
+        self._busy = busy
+        self._eula = eula
+        self._update_buttons()
+
+    def _update_buttons(self) -> None:
+        busy = self._busy
+        eula = self._eula
+        has_rows = self.table.rowCount() > 0
+        has_sel = len(self.table.selectedIndexes()) > 0
+        enable = eula and not busy
+        self.dir_scan_btn.setEnabled(not busy)
+        self.dir_extract_sel.setEnabled(enable and has_sel)
+        self.dir_extract_all.setEnabled(enable and has_rows)
+        self.dir_validate_sel.setEnabled(enable and has_sel)
+        self.dir_validate_all.setEnabled(enable and has_rows)
+        self.compare_btn.setEnabled(not busy)
+
+    def update_status(self, running: int, pending: int) -> None:
+        if running or pending:
+            self.status_label.setText(f"Running {running + pending} tasks...")
+        else:
+            self.status_label.setText("Idle")
+
+    def set_row_status(self, row: int, status: str) -> None:
+        self.table.setItem(row, 3, QTableWidgetItem(status))
+
+    # ----- Actions ----------------------------------------------------
+    def _pick_dir(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose directory")
+        if path:
+            self.dir_root.setText(path)
+
+    def _pick_dir_into(self, edit: QLineEdit) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose directory")
+        if path:
+            edit.setText(path)
+
+    def _filter_table(self, text: str) -> None:
+        text = text.lower()
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 1)
+            self.table.setRowHidden(row, text not in item.text().lower())
+
+    def scan_directory(self) -> None:
+        root = Path(self.dir_root.text())
+        if not root.is_dir():
+            self._log(f"Invalid directory: {root}")
+            return
+        self.table.setRowCount(0)
+        paths = root.rglob("*") if self.dir_recurse.isChecked() else root.glob("*")
+        for p in paths:
+            if not p.is_file():
+                continue
+            ext = p.suffix.lower()
+            if ext == ".pak":
+                name = p.name.lower()
+                if "dlc" in name or name.endswith("_p.pak"):
+                    kind = "PAK-DLC"
+                else:
+                    kind = "PAK"
+            elif ext == ".utoc":
+                kind = "UTOC"
+            elif ext in {".obb", ".aab"} and self.dir_unzip.isChecked():
+                kind = "ZIP"
+            else:
+                continue
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(kind))
+            self.table.setItem(row, 1, QTableWidgetItem(str(p)))
+            self.table.setItem(row, 2, QTableWidgetItem(str(p.stat().st_size)))
+            self.table.setItem(row, 3, QTableWidgetItem("Pending"))
+        self._update_buttons()
+
+    def _rows(self, selected: bool) -> List[int]:
+        if selected:
+            return sorted({i.row() for i in self.table.selectedIndexes()})
+        return list(range(self.table.rowCount()))
+
+    def _extract(self, selected: bool) -> None:
+        if not self.worker:
+            return
+        rows = self._rows(selected)
+        tasks = self._build_tasks(rows, "extract")
+        if tasks:
+            self.worker.enqueue(tasks)
+
+    def _validate(self, selected: bool) -> None:
+        if not self.worker:
+            return
+        rows = self._rows(selected)
+        tasks = self._build_tasks(rows, "validate")
+        if tasks:
+            self.worker.enqueue(tasks)
+
+    def _build_tasks(self, rows: List[int], action: str) -> List[Task]:
+        tasks: List[Task] = []
+        for row in rows:
+            path = Path(self.table.item(row, 1).text())
+            ttype = self.table.item(row, 0).text()
+            if ttype.startswith("PAK"):
+                dest = None if action != "extract" else dest_for(path, "_extracted")
+                argv = build_unrealpak_cmd(
+                    self._get_unrealpak(),
+                    path,
+                    action,
+                    dest,
+                    self._get_filter() or None,
+                )
+                tasks.append(Task("proc", action, path, dest, row, argv))
+            elif ttype.startswith("UTOC"):
+                dest = None if action != "extract" else dest_for(path, "_extracted")
+                argv = build_iostore_cmd(self._get_iostore(), path, action, dest)
+                tasks.append(Task("proc", action, path, dest, row, argv))
+            elif ttype == "ZIP":
+                dest = None if action != "extract" else dest_for(path, "_unzipped")
+                tasks.append(Task("zip", action, path, dest, row))
+        return tasks
+
+    def _compare_builds(self) -> None:
+        if not self.worker:
+            return
+        a = Path(self.compare_a.text())
+        b = Path(self.compare_b.text())
+        if not a.is_dir() or not b.is_dir():
+            self._log("Invalid compare directories")
+            return
+        task = Task("cmp", "compare", a, b, None)
+        self.worker.enqueue([task])

--- a/aegis/ui/widgets/pak_iostore/panel.py
+++ b/aegis/ui/widgets/pak_iostore/panel.py
@@ -131,9 +131,13 @@ class PakIoStorePanel(QWidget):
 
         btn_row = QHBoxLayout()
         self.single_list_btn = QPushButton("List")
+        self.single_search_btn = QPushButton("Search")
         self.single_extract_btn = QPushButton("Extract")
+        self.single_validate_btn = QPushButton("Validate")
         btn_row.addWidget(self.single_list_btn)
+        btn_row.addWidget(self.single_search_btn)
         btn_row.addWidget(self.single_extract_btn)
+        btn_row.addWidget(self.single_validate_btn)
         btn_row.addStretch(1)
         layout.addLayout(btn_row)
 
@@ -166,6 +170,10 @@ class PakIoStorePanel(QWidget):
         self.dir_scan_btn = QPushButton("Scan")
         layout.addWidget(self.dir_scan_btn)
 
+        self.dir_search = QLineEdit()
+        self.dir_search.setPlaceholderText("Search...")
+        layout.addWidget(self.dir_search)
+
         self.table = QTableWidget(0, 4)
         self.table.setHorizontalHeaderLabels(["Type", "Path", "Size", "Status"])
         self.table.setObjectName("pak_table")
@@ -175,10 +183,35 @@ class PakIoStorePanel(QWidget):
         btn_row = QHBoxLayout()
         self.dir_extract_sel = QPushButton("Extract Selected")
         self.dir_extract_all = QPushButton("Extract All")
+        self.dir_validate_sel = QPushButton("Validate Selected")
+        self.dir_validate_all = QPushButton("Validate All")
         btn_row.addWidget(self.dir_extract_sel)
         btn_row.addWidget(self.dir_extract_all)
+        btn_row.addWidget(self.dir_validate_sel)
+        btn_row.addWidget(self.dir_validate_all)
         btn_row.addStretch(1)
         layout.addLayout(btn_row)
+
+        cmp_box = QGroupBox("Compare Builds")
+        cmp_layout = QVBoxLayout()
+        row_a = QHBoxLayout()
+        self.compare_a = QLineEdit()
+        self.compare_a_browse = QPushButton("Browse")
+        row_a.addWidget(QLabel("Dir A"))
+        row_a.addWidget(self.compare_a, 1)
+        row_a.addWidget(self.compare_a_browse)
+        cmp_layout.addLayout(row_a)
+        row_b = QHBoxLayout()
+        self.compare_b = QLineEdit()
+        self.compare_b_browse = QPushButton("Browse")
+        row_b.addWidget(QLabel("Dir B"))
+        row_b.addWidget(self.compare_b, 1)
+        row_b.addWidget(self.compare_b_browse)
+        cmp_layout.addLayout(row_b)
+        self.compare_btn = QPushButton("Compare Builds")
+        cmp_layout.addWidget(self.compare_btn)
+        cmp_box.setLayout(cmp_layout)
+        layout.addWidget(cmp_box)
 
         self.status_label = QLabel("Idle")
         layout.addWidget(self.status_label)
@@ -203,12 +236,24 @@ class PakIoStorePanel(QWidget):
             lambda: self._pick_file(self.aab_file, "AAB Files (*.aab)")
         )
         self.single_list_btn.clicked.connect(self._single_list)
+        self.single_search_btn.clicked.connect(self._single_search)
         self.single_extract_btn.clicked.connect(self._single_extract)
+        self.single_validate_btn.clicked.connect(self._single_validate)
 
         self.dir_browse.clicked.connect(self._pick_dir)
         self.dir_scan_btn.clicked.connect(self.scan_directory)
+        self.dir_search.textChanged.connect(self._filter_table)
         self.dir_extract_sel.clicked.connect(self._dir_extract_selected)
         self.dir_extract_all.clicked.connect(self._dir_extract_all)
+        self.dir_validate_sel.clicked.connect(self._dir_validate_selected)
+        self.dir_validate_all.clicked.connect(self._dir_validate_all)
+        self.compare_a_browse.clicked.connect(
+            lambda: self._pick_dir_into(self.compare_a)
+        )
+        self.compare_b_browse.clicked.connect(
+            lambda: self._pick_dir_into(self.compare_b)
+        )
+        self.compare_btn.clicked.connect(self._compare_builds)
 
         self.eula_chk.toggled.connect(self._update_extract_enabled)
         self.table.itemSelectionChanged.connect(self._update_extract_enabled)
@@ -245,6 +290,26 @@ class PakIoStorePanel(QWidget):
     def _set_row_status(self, row: int, status: str) -> None:
         self.table.setItem(row, 3, QTableWidgetItem(status))
 
+    def _filter_table(self, text: str) -> None:
+        text = text.lower()
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 1)
+            self.table.setRowHidden(row, text not in item.text().lower())
+
+    def _pick_dir_into(self, edit: QLineEdit) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose directory")
+        if path:
+            edit.setText(path)
+
+    def _compare_builds(self) -> None:
+        a = Path(self.compare_a.text())
+        b = Path(self.compare_b.text())
+        if not a.is_dir() or not b.is_dir():
+            self._log("Invalid compare directories")
+            return
+        task = Task("cmp", "compare", a, b, None)
+        self.worker.enqueue([task])
+
     def _on_worker_state(self) -> None:
         running, pending = self.worker.status()
         if running or pending:
@@ -254,12 +319,20 @@ class PakIoStorePanel(QWidget):
         self._update_extract_enabled()
 
     def _update_extract_enabled(self) -> None:
-        enable = self.eula_chk.isChecked() and not self.worker.is_busy()
+        busy = self.worker.is_busy()
+        enable = self.eula_chk.isChecked() and not busy
+        self.single_list_btn.setEnabled(not busy)
+        self.single_search_btn.setEnabled(not busy)
         self.single_extract_btn.setEnabled(enable)
+        self.single_validate_btn.setEnabled(enable)
+        self.dir_scan_btn.setEnabled(not busy)
         has_rows = self.table.rowCount() > 0
         has_sel = len(self.table.selectedIndexes()) > 0
         self.dir_extract_sel.setEnabled(enable and has_sel)
         self.dir_extract_all.setEnabled(enable and has_rows)
+        self.dir_validate_sel.setEnabled(enable and has_sel)
+        self.dir_validate_all.setEnabled(enable and has_rows)
+        self.compare_btn.setEnabled(not busy)
 
     # ----- Scan ---------------------------------------------------------
     def scan_directory(self) -> None:
@@ -274,7 +347,11 @@ class PakIoStorePanel(QWidget):
                 continue
             ext = p.suffix.lower()
             if ext == ".pak":
-                kind = "PAK"
+                name = p.name.lower()
+                if "dlc" in name or name.endswith("_p.pak"):
+                    kind = "PAK-DLC"
+                else:
+                    kind = "PAK"
             elif ext == ".utoc":
                 kind = "UTOC"
             elif ext in {".obb", ".aab"} and self.dir_unzip.isChecked():
@@ -292,39 +369,54 @@ class PakIoStorePanel(QWidget):
     # ----- Task queue ---------------------------------------------------
     def _dir_extract_selected(self) -> None:
         rows = {i.row() for i in self.table.selectedIndexes()}
-        self._enqueue_rows(sorted(rows))
+        self._enqueue_rows(sorted(rows), "extract")
 
     def _dir_extract_all(self) -> None:
-        self._enqueue_rows(list(range(self.table.rowCount())))
+        self._enqueue_rows(list(range(self.table.rowCount())), "extract")
 
-    def _enqueue_rows(self, rows: List[int]) -> None:
+    def _dir_validate_selected(self) -> None:
+        rows = {i.row() for i in self.table.selectedIndexes()}
+        self._enqueue_rows(sorted(rows), "validate")
+
+    def _dir_validate_all(self) -> None:
+        self._enqueue_rows(list(range(self.table.rowCount())), "validate")
+
+    def _enqueue_rows(self, rows: List[int], action: str) -> None:
         tasks: List[Task] = []
         for row in rows:
             path = Path(self.table.item(row, 1).text())
             ttype = self.table.item(row, 0).text()
-            if ttype == "PAK":
-                dest = dest_for(path, "_extracted")
+            if ttype.startswith("PAK"):
+                dest = None if action != "extract" else dest_for(path, "_extracted")
                 argv = build_unrealpak_cmd(
                     self.unrealpak_edit.text(),
                     path,
-                    "extract",
+                    action if action != "search" else "list",
                     dest,
                     self.pak_filter.text().strip() or None,
                 )
-                tasks.append(Task("proc", "extract", path, dest, row, argv))
-            elif ttype == "UTOC":
-                dest = dest_for(path, "_extracted")
+                tasks.append(Task("proc", action, path, dest, row, argv))
+            elif ttype.startswith("UTOC"):
+                dest = None if action != "extract" else dest_for(path, "_extracted")
                 argv = build_iostore_cmd(
-                    self.iostore_edit.text(), path, "extract", dest
+                    self.iostore_edit.text(),
+                    path,
+                    action if action != "search" else "list",
+                    dest,
                 )
-                tasks.append(Task("proc", "extract", path, dest, row, argv))
+                tasks.append(Task("proc", action, path, dest, row, argv))
             elif ttype == "ZIP":
-                dest = dest_for(path, "_unzipped")
-                tasks.append(Task("zip", "extract", path, dest, row))
+                dest = None if action != "extract" else dest_for(path, "_unzipped")
+                tasks.append(Task("zip", action, path, dest, row))
         self.worker.enqueue(tasks)
 
     def _single_list(self) -> None:
         task = self._single_task("list")
+        if task:
+            self.worker.enqueue([task])
+
+    def _single_search(self) -> None:
+        task = self._single_task("search")
         if task:
             self.worker.enqueue([task])
 
@@ -333,6 +425,11 @@ class PakIoStorePanel(QWidget):
             self._log("Ownership checkbox not ticked")
             return
         task = self._single_task("extract")
+        if task:
+            self.worker.enqueue([task])
+
+    def _single_validate(self) -> None:
+        task = self._single_task("validate")
         if task:
             self.worker.enqueue([task])
 
@@ -350,23 +447,39 @@ class PakIoStorePanel(QWidget):
                     self._log(f"Missing file: {path}")
                     return None
                 if kind == "unrealpak":
-                    dest = None if action == "list" else dest_for(path, suf)
+                    mode = (
+                        action if action in {"list", "extract", "validate"} else "list"
+                    )
+                    dest = (
+                        None
+                        if action in {"list", "search", "validate"}
+                        else dest_for(path, suf)
+                    )
                     argv = build_unrealpak_cmd(
                         self.unrealpak_edit.text(),
                         path,
-                        action,
+                        mode,
                         dest,
                         self.pak_filter.text().strip() or None,
                     )
                     return Task("proc", action, path, dest, None, argv)
                 if kind == "iostore":
-                    dest = None if action == "list" else dest_for(path, suf)
-                    argv = build_iostore_cmd(
-                        self.iostore_edit.text(), path, action, dest
+                    mode = (
+                        action if action in {"list", "extract", "validate"} else "list"
                     )
+                    dest = (
+                        None
+                        if action in {"list", "search", "validate"}
+                        else dest_for(path, suf)
+                    )
+                    argv = build_iostore_cmd(self.iostore_edit.text(), path, mode, dest)
                     return Task("proc", action, path, dest, None, argv)
                 tkind = "zip"
-                dest = None if action == "list" else dest_for(path, suf)
+                dest = (
+                    None
+                    if action in {"list", "search", "validate"}
+                    else dest_for(path, suf)
+                )
                 return Task(tkind, action, path, dest, None)
         self._log("No file selected")
         return None

--- a/aegis/ui/widgets/pak_iostore/panel.py
+++ b/aegis/ui/widgets/pak_iostore/panel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -13,14 +12,13 @@ from PySide6.QtWidgets import (
     QPlainTextEdit,
     QPushButton,
     QTabWidget,
-    QTableWidget,
-    QTableWidgetItem,
     QVBoxLayout,
     QWidget,
 )
 
-from .worker import PakWorker, Task
-from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+from .directory_tab import DirectoryTab
+from .single_tab import SingleFileTab
+from .worker import PakWorker
 
 
 class PakIoStorePanel(QWidget):
@@ -38,14 +36,25 @@ class PakIoStorePanel(QWidget):
             self.preview.setPlainText,
             lambda: self.unrealpak_edit.text(),
             lambda: self.iostore_edit.text(),
-            lambda: self.pak_filter.text().strip(),
-            lambda: self.dir_unzip_extract.isChecked(),
-            self._set_row_status,
+            lambda: self.single_tab.pak_filter.text().strip(),
+            lambda: self.dir_tab.dir_unzip_extract.isChecked(),
+            self.dir_tab.set_row_status,
             self._on_worker_state,
+        )
+        self.single_tab.set_worker(
+            self.worker,
+            lambda: self.unrealpak_edit.text(),
+            lambda: self.iostore_edit.text(),
+        )
+        self.dir_tab.set_worker(
+            self.worker,
+            lambda: self.unrealpak_edit.text(),
+            lambda: self.iostore_edit.text(),
+            lambda: self.single_tab.pak_filter.text().strip(),
         )
         self._on_worker_state()
 
-    # ----- UI -----------------------------------------------------------
+    # ----- UI ---------------------------------------------------------
     def _build_ui(self) -> None:
         root = QVBoxLayout(self)
 
@@ -69,8 +78,10 @@ class PakIoStorePanel(QWidget):
         root.addWidget(tools_box)
 
         self.mode_tabs = QTabWidget()
-        self._build_single_tab()
-        self._build_dir_tab()
+        self.single_tab = SingleFileTab(self._log)
+        self.dir_tab = DirectoryTab(self._log)
+        self.mode_tabs.addTab(self.single_tab, "Single File")
+        self.mode_tabs.addTab(self.dir_tab, "Directory")
         root.addWidget(self.mode_tabs)
 
         self.eula_chk = QCheckBox("I certify I own these files")
@@ -86,181 +97,13 @@ class PakIoStorePanel(QWidget):
         self.log.setObjectName("pak_log")
         root.addWidget(self.log)
 
-    def _build_single_tab(self) -> None:
-        tab = QWidget()
-        layout = QVBoxLayout(tab)
-
-        self.pak_file = QLineEdit()
-        self.pak_browse = QPushButton("Browse")
-        row_pak = QHBoxLayout()
-        row_pak.addWidget(QLabel(".pak"))
-        row_pak.addWidget(self.pak_file, 1)
-        row_pak.addWidget(self.pak_browse)
-        layout.addLayout(row_pak)
-
-        self.pak_filter = QLineEdit()
-        self.pak_filter.setObjectName("pak_filter_edit")
-        row_filter = QHBoxLayout()
-        row_filter.addWidget(QLabel("Filter"))
-        row_filter.addWidget(self.pak_filter, 1)
-        layout.addLayout(row_filter)
-
-        self.utoc_file = QLineEdit()
-        self.utoc_browse = QPushButton("Browse")
-        row_utoc = QHBoxLayout()
-        row_utoc.addWidget(QLabel(".utoc"))
-        row_utoc.addWidget(self.utoc_file, 1)
-        row_utoc.addWidget(self.utoc_browse)
-        layout.addLayout(row_utoc)
-
-        self.obb_file = QLineEdit()
-        self.obb_browse = QPushButton("Browse")
-        row_obb = QHBoxLayout()
-        row_obb.addWidget(QLabel(".obb"))
-        row_obb.addWidget(self.obb_file, 1)
-        row_obb.addWidget(self.obb_browse)
-        layout.addLayout(row_obb)
-
-        self.aab_file = QLineEdit()
-        self.aab_browse = QPushButton("Browse")
-        row_aab = QHBoxLayout()
-        row_aab.addWidget(QLabel(".aab"))
-        row_aab.addWidget(self.aab_file, 1)
-        row_aab.addWidget(self.aab_browse)
-        layout.addLayout(row_aab)
-
-        btn_row = QHBoxLayout()
-        self.single_list_btn = QPushButton("List")
-        self.single_search_btn = QPushButton("Search")
-        self.single_extract_btn = QPushButton("Extract")
-        self.single_validate_btn = QPushButton("Validate")
-        btn_row.addWidget(self.single_list_btn)
-        btn_row.addWidget(self.single_search_btn)
-        btn_row.addWidget(self.single_extract_btn)
-        btn_row.addWidget(self.single_validate_btn)
-        btn_row.addStretch(1)
-        layout.addLayout(btn_row)
-
-        self.mode_tabs.addTab(tab, "Single File")
-
-    def _build_dir_tab(self) -> None:
-        tab = QWidget()
-        layout = QVBoxLayout(tab)
-
-        dir_row = QHBoxLayout()
-        self.dir_root = QLineEdit()
-        self.dir_browse = QPushButton("Browse")
-        dir_row.addWidget(QLabel("Root directory"))
-        dir_row.addWidget(self.dir_root, 1)
-        dir_row.addWidget(self.dir_browse)
-        layout.addLayout(dir_row)
-
-        self.dir_recurse = QCheckBox("Recurse subdirectories")
-        self.dir_recurse.setChecked(True)
-        self.dir_unzip = QCheckBox("Also unzip .obb/.aab files")
-        self.dir_unzip.setChecked(True)
-        self.dir_unzip_extract = QCheckBox(
-            "After unzip, also extract any .pak found inside"
-        )
-        self.dir_unzip_extract.setChecked(True)
-        layout.addWidget(self.dir_recurse)
-        layout.addWidget(self.dir_unzip)
-        layout.addWidget(self.dir_unzip_extract)
-
-        self.dir_scan_btn = QPushButton("Scan")
-        layout.addWidget(self.dir_scan_btn)
-
-        self.dir_search = QLineEdit()
-        self.dir_search.setPlaceholderText("Search...")
-        layout.addWidget(self.dir_search)
-
-        self.table = QTableWidget(0, 4)
-        self.table.setHorizontalHeaderLabels(["Type", "Path", "Size", "Status"])
-        self.table.setObjectName("pak_table")
-        self.table.horizontalHeader().setStretchLastSection(True)
-        layout.addWidget(self.table)
-
-        btn_row = QHBoxLayout()
-        self.dir_extract_sel = QPushButton("Extract Selected")
-        self.dir_extract_all = QPushButton("Extract All")
-        self.dir_validate_sel = QPushButton("Validate Selected")
-        self.dir_validate_all = QPushButton("Validate All")
-        btn_row.addWidget(self.dir_extract_sel)
-        btn_row.addWidget(self.dir_extract_all)
-        btn_row.addWidget(self.dir_validate_sel)
-        btn_row.addWidget(self.dir_validate_all)
-        btn_row.addStretch(1)
-        layout.addLayout(btn_row)
-
-        cmp_box = QGroupBox("Compare Builds")
-        cmp_layout = QVBoxLayout()
-        row_a = QHBoxLayout()
-        self.compare_a = QLineEdit()
-        self.compare_a_browse = QPushButton("Browse")
-        row_a.addWidget(QLabel("Dir A"))
-        row_a.addWidget(self.compare_a, 1)
-        row_a.addWidget(self.compare_a_browse)
-        cmp_layout.addLayout(row_a)
-        row_b = QHBoxLayout()
-        self.compare_b = QLineEdit()
-        self.compare_b_browse = QPushButton("Browse")
-        row_b.addWidget(QLabel("Dir B"))
-        row_b.addWidget(self.compare_b, 1)
-        row_b.addWidget(self.compare_b_browse)
-        cmp_layout.addLayout(row_b)
-        self.compare_btn = QPushButton("Compare Builds")
-        cmp_layout.addWidget(self.compare_btn)
-        cmp_box.setLayout(cmp_layout)
-        layout.addWidget(cmp_box)
-
-        self.status_label = QLabel("Idle")
-        layout.addWidget(self.status_label)
-
-        self.mode_tabs.addTab(tab, "Directory")
-
-    # ----- Connections --------------------------------------------------
+    # ----- Connections -----------------------------------------------
     def _connect(self) -> None:
         self.unrealpak_browse.clicked.connect(self._pick_unrealpak)
         self.iostore_browse.clicked.connect(self._pick_iostore)
+        self.eula_chk.toggled.connect(self._update_enabled)
 
-        self.pak_browse.clicked.connect(
-            lambda: self._pick_file(self.pak_file, "Pak Files (*.pak)")
-        )
-        self.utoc_browse.clicked.connect(
-            lambda: self._pick_file(self.utoc_file, "IoStore Files (*.utoc)")
-        )
-        self.obb_browse.clicked.connect(
-            lambda: self._pick_file(self.obb_file, "OBB Files (*.obb)")
-        )
-        self.aab_browse.clicked.connect(
-            lambda: self._pick_file(self.aab_file, "AAB Files (*.aab)")
-        )
-        self.single_list_btn.clicked.connect(self._single_list)
-        self.single_search_btn.clicked.connect(self._single_search)
-        self.single_extract_btn.clicked.connect(self._single_extract)
-        self.single_validate_btn.clicked.connect(self._single_validate)
-
-        self.dir_browse.clicked.connect(self._pick_dir)
-        self.dir_scan_btn.clicked.connect(self.scan_directory)
-        self.dir_search.textChanged.connect(self._filter_table)
-        self.dir_extract_sel.clicked.connect(self._dir_extract_selected)
-        self.dir_extract_all.clicked.connect(self._dir_extract_all)
-        self.dir_validate_sel.clicked.connect(self._dir_validate_selected)
-        self.dir_validate_all.clicked.connect(self._dir_validate_all)
-        self.compare_a_browse.clicked.connect(
-            lambda: self._pick_dir_into(self.compare_a)
-        )
-        self.compare_b_browse.clicked.connect(
-            lambda: self._pick_dir_into(self.compare_b)
-        )
-        self.compare_btn.clicked.connect(self._compare_builds)
-
-        self.eula_chk.toggled.connect(self._update_extract_enabled)
-        self.table.itemSelectionChanged.connect(self._update_extract_enabled)
-
-        self._update_extract_enabled()
-
-    # ----- Helpers ------------------------------------------------------
+    # ----- Helpers ---------------------------------------------------
     def _pick_unrealpak(self) -> None:
         path, _ = QFileDialog.getOpenFileName(self, "UnrealPak", "", "Executables (*)")
         if path:
@@ -273,213 +116,16 @@ class PakIoStorePanel(QWidget):
         if path:
             self.iostore_edit.setText(path)
 
-    def _pick_file(self, edit: QLineEdit, filt: str) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Choose file", "", filt)
-        if path:
-            edit.setText(path)
-        self._update_extract_enabled()
-
-    def _pick_dir(self) -> None:
-        path = QFileDialog.getExistingDirectory(self, "Choose directory")
-        if path:
-            self.dir_root.setText(path)
-
     def _log(self, text: str) -> None:
         self.log.appendPlainText(text)
 
-    def _set_row_status(self, row: int, status: str) -> None:
-        self.table.setItem(row, 3, QTableWidgetItem(status))
-
-    def _filter_table(self, text: str) -> None:
-        text = text.lower()
-        for row in range(self.table.rowCount()):
-            item = self.table.item(row, 1)
-            self.table.setRowHidden(row, text not in item.text().lower())
-
-    def _pick_dir_into(self, edit: QLineEdit) -> None:
-        path = QFileDialog.getExistingDirectory(self, "Choose directory")
-        if path:
-            edit.setText(path)
-
-    def _compare_builds(self) -> None:
-        a = Path(self.compare_a.text())
-        b = Path(self.compare_b.text())
-        if not a.is_dir() or not b.is_dir():
-            self._log("Invalid compare directories")
-            return
-        task = Task("cmp", "compare", a, b, None)
-        self.worker.enqueue([task])
-
     def _on_worker_state(self) -> None:
         running, pending = self.worker.status()
-        if running or pending:
-            self.status_label.setText(f"Running {running + pending} tasks...")
-        else:
-            self.status_label.setText("Idle")
-        self._update_extract_enabled()
+        self.dir_tab.update_status(running, pending)
+        self._update_enabled()
 
-    def _update_extract_enabled(self) -> None:
+    def _update_enabled(self) -> None:
         busy = self.worker.is_busy()
-        enable = self.eula_chk.isChecked() and not busy
-        self.single_list_btn.setEnabled(not busy)
-        self.single_search_btn.setEnabled(not busy)
-        self.single_extract_btn.setEnabled(enable)
-        self.single_validate_btn.setEnabled(enable)
-        self.dir_scan_btn.setEnabled(not busy)
-        has_rows = self.table.rowCount() > 0
-        has_sel = len(self.table.selectedIndexes()) > 0
-        self.dir_extract_sel.setEnabled(enable and has_sel)
-        self.dir_extract_all.setEnabled(enable and has_rows)
-        self.dir_validate_sel.setEnabled(enable and has_sel)
-        self.dir_validate_all.setEnabled(enable and has_rows)
-        self.compare_btn.setEnabled(not busy)
-
-    # ----- Scan ---------------------------------------------------------
-    def scan_directory(self) -> None:
-        root = Path(self.dir_root.text())
-        if not root.is_dir():
-            self._log(f"Invalid directory: {root}")
-            return
-        self.table.setRowCount(0)
-        paths = root.rglob("*") if self.dir_recurse.isChecked() else root.glob("*")
-        for p in paths:
-            if not p.is_file():
-                continue
-            ext = p.suffix.lower()
-            if ext == ".pak":
-                name = p.name.lower()
-                if "dlc" in name or name.endswith("_p.pak"):
-                    kind = "PAK-DLC"
-                else:
-                    kind = "PAK"
-            elif ext == ".utoc":
-                kind = "UTOC"
-            elif ext in {".obb", ".aab"} and self.dir_unzip.isChecked():
-                kind = "ZIP"
-            else:
-                continue
-            row = self.table.rowCount()
-            self.table.insertRow(row)
-            self.table.setItem(row, 0, QTableWidgetItem(kind))
-            self.table.setItem(row, 1, QTableWidgetItem(str(p)))
-            self.table.setItem(row, 2, QTableWidgetItem(str(p.stat().st_size)))
-            self.table.setItem(row, 3, QTableWidgetItem("Pending"))
-        self._update_extract_enabled()
-
-    # ----- Task queue ---------------------------------------------------
-    def _dir_extract_selected(self) -> None:
-        rows = {i.row() for i in self.table.selectedIndexes()}
-        self._enqueue_rows(sorted(rows), "extract")
-
-    def _dir_extract_all(self) -> None:
-        self._enqueue_rows(list(range(self.table.rowCount())), "extract")
-
-    def _dir_validate_selected(self) -> None:
-        rows = {i.row() for i in self.table.selectedIndexes()}
-        self._enqueue_rows(sorted(rows), "validate")
-
-    def _dir_validate_all(self) -> None:
-        self._enqueue_rows(list(range(self.table.rowCount())), "validate")
-
-    def _enqueue_rows(self, rows: List[int], action: str) -> None:
-        tasks: List[Task] = []
-        for row in rows:
-            path = Path(self.table.item(row, 1).text())
-            ttype = self.table.item(row, 0).text()
-            if ttype.startswith("PAK"):
-                dest = None if action != "extract" else dest_for(path, "_extracted")
-                argv = build_unrealpak_cmd(
-                    self.unrealpak_edit.text(),
-                    path,
-                    action if action != "search" else "list",
-                    dest,
-                    self.pak_filter.text().strip() or None,
-                )
-                tasks.append(Task("proc", action, path, dest, row, argv))
-            elif ttype.startswith("UTOC"):
-                dest = None if action != "extract" else dest_for(path, "_extracted")
-                argv = build_iostore_cmd(
-                    self.iostore_edit.text(),
-                    path,
-                    action if action != "search" else "list",
-                    dest,
-                )
-                tasks.append(Task("proc", action, path, dest, row, argv))
-            elif ttype == "ZIP":
-                dest = None if action != "extract" else dest_for(path, "_unzipped")
-                tasks.append(Task("zip", action, path, dest, row))
-        self.worker.enqueue(tasks)
-
-    def _single_list(self) -> None:
-        task = self._single_task("list")
-        if task:
-            self.worker.enqueue([task])
-
-    def _single_search(self) -> None:
-        task = self._single_task("search")
-        if task:
-            self.worker.enqueue([task])
-
-    def _single_extract(self) -> None:
-        if not self.eula_chk.isChecked():
-            self._log("Ownership checkbox not ticked")
-            return
-        task = self._single_task("extract")
-        if task:
-            self.worker.enqueue([task])
-
-    def _single_validate(self) -> None:
-        task = self._single_task("validate")
-        if task:
-            self.worker.enqueue([task])
-
-    def _single_task(self, action: str) -> Optional[Task]:
-        mapping = [
-            (self.pak_file, "unrealpak", "_extracted"),
-            (self.utoc_file, "iostore", "_extracted"),
-            (self.obb_file, "zip", "_unzipped"),
-            (self.aab_file, "zip", "_unzipped"),
-        ]
-        for edit, kind, suf in mapping:
-            if edit.text():
-                path = Path(edit.text())
-                if not path.exists():
-                    self._log(f"Missing file: {path}")
-                    return None
-                if kind == "unrealpak":
-                    mode = (
-                        action if action in {"list", "extract", "validate"} else "list"
-                    )
-                    dest = (
-                        None
-                        if action in {"list", "search", "validate"}
-                        else dest_for(path, suf)
-                    )
-                    argv = build_unrealpak_cmd(
-                        self.unrealpak_edit.text(),
-                        path,
-                        mode,
-                        dest,
-                        self.pak_filter.text().strip() or None,
-                    )
-                    return Task("proc", action, path, dest, None, argv)
-                if kind == "iostore":
-                    mode = (
-                        action if action in {"list", "extract", "validate"} else "list"
-                    )
-                    dest = (
-                        None
-                        if action in {"list", "search", "validate"}
-                        else dest_for(path, suf)
-                    )
-                    argv = build_iostore_cmd(self.iostore_edit.text(), path, mode, dest)
-                    return Task("proc", action, path, dest, None, argv)
-                tkind = "zip"
-                dest = (
-                    None
-                    if action in {"list", "search", "validate"}
-                    else dest_for(path, suf)
-                )
-                return Task(tkind, action, path, dest, None)
-        self._log("No file selected")
-        return None
+        eula = self.eula_chk.isChecked()
+        self.single_tab.update_enabled(busy, eula)
+        self.dir_tab.update_enabled(busy, eula)

--- a/aegis/ui/widgets/pak_iostore/panel.py
+++ b/aegis/ui/widgets/pak_iostore/panel.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPlainTextEdit,
+    QPushButton,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .worker import PakWorker, Task
+from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+
+
+class PakIoStorePanel(QWidget):
+    """Panel handling Pak/IoStore operations."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("tab_pak")
+
+        self._build_ui()
+        self._connect()
+
+        self.worker = PakWorker(
+            self._log,
+            self.preview.setPlainText,
+            lambda: self.unrealpak_edit.text(),
+            lambda: self.iostore_edit.text(),
+            lambda: self.pak_filter.text().strip(),
+            lambda: self.dir_unzip_extract.isChecked(),
+            self._set_row_status,
+            self._on_worker_state,
+        )
+        self._on_worker_state()
+
+    # ----- UI -----------------------------------------------------------
+    def _build_ui(self) -> None:
+        root = QVBoxLayout(self)
+
+        tools_box = QGroupBox("Tool Paths")
+        tl = QVBoxLayout()
+        self.unrealpak_edit = QLineEdit()
+        self.unrealpak_browse = QPushButton("Browse")
+        r1 = QHBoxLayout()
+        r1.addWidget(QLabel("UnrealPak.exe"))
+        r1.addWidget(self.unrealpak_edit, 1)
+        r1.addWidget(self.unrealpak_browse)
+        tl.addLayout(r1)
+        self.iostore_edit = QLineEdit()
+        self.iostore_browse = QPushButton("Browse")
+        r2 = QHBoxLayout()
+        r2.addWidget(QLabel("IoStoreUtilities.exe"))
+        r2.addWidget(self.iostore_edit, 1)
+        r2.addWidget(self.iostore_browse)
+        tl.addLayout(r2)
+        tools_box.setLayout(tl)
+        root.addWidget(tools_box)
+
+        self.mode_tabs = QTabWidget()
+        self._build_single_tab()
+        self._build_dir_tab()
+        root.addWidget(self.mode_tabs)
+
+        self.eula_chk = QCheckBox("I certify I own these files")
+        root.addWidget(self.eula_chk)
+
+        self.preview = QPlainTextEdit()
+        self.preview.setReadOnly(True)
+        self.preview.setObjectName("pak_preview")
+        root.addWidget(self.preview)
+
+        self.log = QPlainTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setObjectName("pak_log")
+        root.addWidget(self.log)
+
+    def _build_single_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+
+        self.pak_file = QLineEdit()
+        self.pak_browse = QPushButton("Browse")
+        row_pak = QHBoxLayout()
+        row_pak.addWidget(QLabel(".pak"))
+        row_pak.addWidget(self.pak_file, 1)
+        row_pak.addWidget(self.pak_browse)
+        layout.addLayout(row_pak)
+
+        self.pak_filter = QLineEdit()
+        self.pak_filter.setObjectName("pak_filter_edit")
+        row_filter = QHBoxLayout()
+        row_filter.addWidget(QLabel("Filter"))
+        row_filter.addWidget(self.pak_filter, 1)
+        layout.addLayout(row_filter)
+
+        self.utoc_file = QLineEdit()
+        self.utoc_browse = QPushButton("Browse")
+        row_utoc = QHBoxLayout()
+        row_utoc.addWidget(QLabel(".utoc"))
+        row_utoc.addWidget(self.utoc_file, 1)
+        row_utoc.addWidget(self.utoc_browse)
+        layout.addLayout(row_utoc)
+
+        self.obb_file = QLineEdit()
+        self.obb_browse = QPushButton("Browse")
+        row_obb = QHBoxLayout()
+        row_obb.addWidget(QLabel(".obb"))
+        row_obb.addWidget(self.obb_file, 1)
+        row_obb.addWidget(self.obb_browse)
+        layout.addLayout(row_obb)
+
+        self.aab_file = QLineEdit()
+        self.aab_browse = QPushButton("Browse")
+        row_aab = QHBoxLayout()
+        row_aab.addWidget(QLabel(".aab"))
+        row_aab.addWidget(self.aab_file, 1)
+        row_aab.addWidget(self.aab_browse)
+        layout.addLayout(row_aab)
+
+        btn_row = QHBoxLayout()
+        self.single_list_btn = QPushButton("List")
+        self.single_extract_btn = QPushButton("Extract")
+        btn_row.addWidget(self.single_list_btn)
+        btn_row.addWidget(self.single_extract_btn)
+        btn_row.addStretch(1)
+        layout.addLayout(btn_row)
+
+        self.mode_tabs.addTab(tab, "Single File")
+
+    def _build_dir_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+
+        dir_row = QHBoxLayout()
+        self.dir_root = QLineEdit()
+        self.dir_browse = QPushButton("Browse")
+        dir_row.addWidget(QLabel("Root directory"))
+        dir_row.addWidget(self.dir_root, 1)
+        dir_row.addWidget(self.dir_browse)
+        layout.addLayout(dir_row)
+
+        self.dir_recurse = QCheckBox("Recurse subdirectories")
+        self.dir_recurse.setChecked(True)
+        self.dir_unzip = QCheckBox("Also unzip .obb/.aab files")
+        self.dir_unzip.setChecked(True)
+        self.dir_unzip_extract = QCheckBox(
+            "After unzip, also extract any .pak found inside"
+        )
+        self.dir_unzip_extract.setChecked(True)
+        layout.addWidget(self.dir_recurse)
+        layout.addWidget(self.dir_unzip)
+        layout.addWidget(self.dir_unzip_extract)
+
+        self.dir_scan_btn = QPushButton("Scan")
+        layout.addWidget(self.dir_scan_btn)
+
+        self.table = QTableWidget(0, 4)
+        self.table.setHorizontalHeaderLabels(["Type", "Path", "Size", "Status"])
+        self.table.setObjectName("pak_table")
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        btn_row = QHBoxLayout()
+        self.dir_extract_sel = QPushButton("Extract Selected")
+        self.dir_extract_all = QPushButton("Extract All")
+        btn_row.addWidget(self.dir_extract_sel)
+        btn_row.addWidget(self.dir_extract_all)
+        btn_row.addStretch(1)
+        layout.addLayout(btn_row)
+
+        self.status_label = QLabel("Idle")
+        layout.addWidget(self.status_label)
+
+        self.mode_tabs.addTab(tab, "Directory")
+
+    # ----- Connections --------------------------------------------------
+    def _connect(self) -> None:
+        self.unrealpak_browse.clicked.connect(self._pick_unrealpak)
+        self.iostore_browse.clicked.connect(self._pick_iostore)
+
+        self.pak_browse.clicked.connect(
+            lambda: self._pick_file(self.pak_file, "Pak Files (*.pak)")
+        )
+        self.utoc_browse.clicked.connect(
+            lambda: self._pick_file(self.utoc_file, "IoStore Files (*.utoc)")
+        )
+        self.obb_browse.clicked.connect(
+            lambda: self._pick_file(self.obb_file, "OBB Files (*.obb)")
+        )
+        self.aab_browse.clicked.connect(
+            lambda: self._pick_file(self.aab_file, "AAB Files (*.aab)")
+        )
+        self.single_list_btn.clicked.connect(self._single_list)
+        self.single_extract_btn.clicked.connect(self._single_extract)
+
+        self.dir_browse.clicked.connect(self._pick_dir)
+        self.dir_scan_btn.clicked.connect(self.scan_directory)
+        self.dir_extract_sel.clicked.connect(self._dir_extract_selected)
+        self.dir_extract_all.clicked.connect(self._dir_extract_all)
+
+        self.eula_chk.toggled.connect(self._update_extract_enabled)
+        self.table.itemSelectionChanged.connect(self._update_extract_enabled)
+
+        self._update_extract_enabled()
+
+    # ----- Helpers ------------------------------------------------------
+    def _pick_unrealpak(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "UnrealPak", "", "Executables (*)")
+        if path:
+            self.unrealpak_edit.setText(path)
+
+    def _pick_iostore(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "IoStoreUtilities", "", "Executables (*)"
+        )
+        if path:
+            self.iostore_edit.setText(path)
+
+    def _pick_file(self, edit: QLineEdit, filt: str) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Choose file", "", filt)
+        if path:
+            edit.setText(path)
+        self._update_extract_enabled()
+
+    def _pick_dir(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose directory")
+        if path:
+            self.dir_root.setText(path)
+
+    def _log(self, text: str) -> None:
+        self.log.appendPlainText(text)
+
+    def _set_row_status(self, row: int, status: str) -> None:
+        self.table.setItem(row, 3, QTableWidgetItem(status))
+
+    def _on_worker_state(self) -> None:
+        running, pending = self.worker.status()
+        if running or pending:
+            self.status_label.setText(f"Running {running + pending} tasks...")
+        else:
+            self.status_label.setText("Idle")
+        self._update_extract_enabled()
+
+    def _update_extract_enabled(self) -> None:
+        enable = self.eula_chk.isChecked() and not self.worker.is_busy()
+        self.single_extract_btn.setEnabled(enable)
+        has_rows = self.table.rowCount() > 0
+        has_sel = len(self.table.selectedIndexes()) > 0
+        self.dir_extract_sel.setEnabled(enable and has_sel)
+        self.dir_extract_all.setEnabled(enable and has_rows)
+
+    # ----- Scan ---------------------------------------------------------
+    def scan_directory(self) -> None:
+        root = Path(self.dir_root.text())
+        if not root.is_dir():
+            self._log(f"Invalid directory: {root}")
+            return
+        self.table.setRowCount(0)
+        paths = root.rglob("*") if self.dir_recurse.isChecked() else root.glob("*")
+        for p in paths:
+            if not p.is_file():
+                continue
+            ext = p.suffix.lower()
+            if ext == ".pak":
+                kind = "PAK"
+            elif ext == ".utoc":
+                kind = "UTOC"
+            elif ext in {".obb", ".aab"} and self.dir_unzip.isChecked():
+                kind = "ZIP"
+            else:
+                continue
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(kind))
+            self.table.setItem(row, 1, QTableWidgetItem(str(p)))
+            self.table.setItem(row, 2, QTableWidgetItem(str(p.stat().st_size)))
+            self.table.setItem(row, 3, QTableWidgetItem("Pending"))
+        self._update_extract_enabled()
+
+    # ----- Task queue ---------------------------------------------------
+    def _dir_extract_selected(self) -> None:
+        rows = {i.row() for i in self.table.selectedIndexes()}
+        self._enqueue_rows(sorted(rows))
+
+    def _dir_extract_all(self) -> None:
+        self._enqueue_rows(list(range(self.table.rowCount())))
+
+    def _enqueue_rows(self, rows: List[int]) -> None:
+        tasks: List[Task] = []
+        for row in rows:
+            path = Path(self.table.item(row, 1).text())
+            ttype = self.table.item(row, 0).text()
+            if ttype == "PAK":
+                dest = dest_for(path, "_extracted")
+                argv = build_unrealpak_cmd(
+                    self.unrealpak_edit.text(),
+                    path,
+                    "extract",
+                    dest,
+                    self.pak_filter.text().strip() or None,
+                )
+                tasks.append(Task("proc", "extract", path, dest, row, argv))
+            elif ttype == "UTOC":
+                dest = dest_for(path, "_extracted")
+                argv = build_iostore_cmd(
+                    self.iostore_edit.text(), path, "extract", dest
+                )
+                tasks.append(Task("proc", "extract", path, dest, row, argv))
+            elif ttype == "ZIP":
+                dest = dest_for(path, "_unzipped")
+                tasks.append(Task("zip", "extract", path, dest, row))
+        self.worker.enqueue(tasks)
+
+    def _single_list(self) -> None:
+        task = self._single_task("list")
+        if task:
+            self.worker.enqueue([task])
+
+    def _single_extract(self) -> None:
+        if not self.eula_chk.isChecked():
+            self._log("Ownership checkbox not ticked")
+            return
+        task = self._single_task("extract")
+        if task:
+            self.worker.enqueue([task])
+
+    def _single_task(self, action: str) -> Optional[Task]:
+        mapping = [
+            (self.pak_file, "unrealpak", "_extracted"),
+            (self.utoc_file, "iostore", "_extracted"),
+            (self.obb_file, "zip", "_unzipped"),
+            (self.aab_file, "zip", "_unzipped"),
+        ]
+        for edit, kind, suf in mapping:
+            if edit.text():
+                path = Path(edit.text())
+                if not path.exists():
+                    self._log(f"Missing file: {path}")
+                    return None
+                if kind == "unrealpak":
+                    dest = None if action == "list" else dest_for(path, suf)
+                    argv = build_unrealpak_cmd(
+                        self.unrealpak_edit.text(),
+                        path,
+                        action,
+                        dest,
+                        self.pak_filter.text().strip() or None,
+                    )
+                    return Task("proc", action, path, dest, None, argv)
+                if kind == "iostore":
+                    dest = None if action == "list" else dest_for(path, suf)
+                    argv = build_iostore_cmd(
+                        self.iostore_edit.text(), path, action, dest
+                    )
+                    return Task("proc", action, path, dest, None, argv)
+                tkind = "zip"
+                dest = None if action == "list" else dest_for(path, suf)
+                return Task(tkind, action, path, dest, None)
+        self._log("No file selected")
+        return None

--- a/aegis/ui/widgets/pak_iostore/single_tab.py
+++ b/aegis/ui/widgets/pak_iostore/single_tab.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+from .worker import PakWorker, Task
+
+
+class SingleFileTab(QWidget):
+    """Sub-widget handling single-file Pak/IoStore actions."""
+
+    def __init__(
+        self, log_cb: Callable[[str], None], parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self._log = log_cb
+        self.worker: Optional[PakWorker] = None
+        self._unrealpak: Callable[[], str] = lambda: ""
+        self._iostore: Callable[[], str] = lambda: ""
+        self._busy = False
+        self._eula = False
+        self._build_ui()
+        self._connect()
+
+    # ------------------------------------------------------------------
+    def set_worker(
+        self,
+        worker: PakWorker,
+        unrealpak: Callable[[], str],
+        iostore: Callable[[], str],
+    ) -> None:
+        self.worker = worker
+        self._unrealpak = unrealpak
+        self._iostore = iostore
+
+    # ----- UI ---------------------------------------------------------
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        self.pak_file = QLineEdit()
+        self.pak_browse = QPushButton("Browse")
+        row_pak = QHBoxLayout()
+        row_pak.addWidget(QLabel(".pak"))
+        row_pak.addWidget(self.pak_file, 1)
+        row_pak.addWidget(self.pak_browse)
+        layout.addLayout(row_pak)
+
+        self.pak_filter = QLineEdit()
+        self.pak_filter.setObjectName("pak_filter_edit")
+        row_filter = QHBoxLayout()
+        row_filter.addWidget(QLabel("Filter"))
+        row_filter.addWidget(self.pak_filter, 1)
+        layout.addLayout(row_filter)
+
+        self.utoc_file = QLineEdit()
+        self.utoc_browse = QPushButton("Browse")
+        row_utoc = QHBoxLayout()
+        row_utoc.addWidget(QLabel(".utoc"))
+        row_utoc.addWidget(self.utoc_file, 1)
+        row_utoc.addWidget(self.utoc_browse)
+        layout.addLayout(row_utoc)
+
+        self.obb_file = QLineEdit()
+        self.obb_browse = QPushButton("Browse")
+        row_obb = QHBoxLayout()
+        row_obb.addWidget(QLabel(".obb"))
+        row_obb.addWidget(self.obb_file, 1)
+        row_obb.addWidget(self.obb_browse)
+        layout.addLayout(row_obb)
+
+        self.aab_file = QLineEdit()
+        self.aab_browse = QPushButton("Browse")
+        row_aab = QHBoxLayout()
+        row_aab.addWidget(QLabel(".aab"))
+        row_aab.addWidget(self.aab_file, 1)
+        row_aab.addWidget(self.aab_browse)
+        layout.addLayout(row_aab)
+
+        btn_row = QHBoxLayout()
+        self.single_list_btn = QPushButton("List")
+        self.single_search_btn = QPushButton("Search")
+        self.single_extract_btn = QPushButton("Extract")
+        self.single_validate_btn = QPushButton("Validate")
+        btn_row.addWidget(self.single_list_btn)
+        btn_row.addWidget(self.single_search_btn)
+        btn_row.addWidget(self.single_extract_btn)
+        btn_row.addWidget(self.single_validate_btn)
+        btn_row.addStretch(1)
+        layout.addLayout(btn_row)
+
+    def _connect(self) -> None:
+        self.pak_browse.clicked.connect(
+            lambda: self._pick_file(self.pak_file, "Pak Files (*.pak)")
+        )
+        self.utoc_browse.clicked.connect(
+            lambda: self._pick_file(self.utoc_file, "IoStore Files (*.utoc)")
+        )
+        self.obb_browse.clicked.connect(
+            lambda: self._pick_file(self.obb_file, "OBB Files (*.obb)")
+        )
+        self.aab_browse.clicked.connect(
+            lambda: self._pick_file(self.aab_file, "AAB Files (*.aab)")
+        )
+        self.single_list_btn.clicked.connect(lambda: self._run("list"))
+        self.single_search_btn.clicked.connect(lambda: self._run("search"))
+        self.single_extract_btn.clicked.connect(lambda: self._run("extract"))
+        self.single_validate_btn.clicked.connect(lambda: self._run("validate"))
+
+    # ----- State ------------------------------------------------------
+    def update_enabled(self, busy: bool, eula: bool) -> None:
+        self._busy = busy
+        self._eula = eula
+        enable = eula and not busy
+        self.single_list_btn.setEnabled(not busy)
+        self.single_search_btn.setEnabled(not busy)
+        self.single_extract_btn.setEnabled(enable)
+        self.single_validate_btn.setEnabled(enable)
+
+    # ----- Actions ----------------------------------------------------
+    def _pick_file(self, edit: QLineEdit, filt: str) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Choose file", "", filt)
+        if path:
+            edit.setText(path)
+
+    def _run(self, action: str) -> None:
+        if not self.worker:
+            return
+        if action == "extract" and not self._eula:
+            self._log("Ownership checkbox not ticked")
+            return
+        task = self._build_task(action)
+        if task:
+            self.worker.enqueue([task])
+
+    def _build_task(self, action: str) -> Optional[Task]:
+        mapping = [
+            (self.pak_file, "unrealpak", "_extracted"),
+            (self.utoc_file, "iostore", "_extracted"),
+            (self.obb_file, "zip", "_unzipped"),
+            (self.aab_file, "zip", "_unzipped"),
+        ]
+        for edit, kind, suf in mapping:
+            if edit.text():
+                path = Path(edit.text())
+                if not path.exists():
+                    self._log(f"Missing file: {path}")
+                    return None
+                if kind == "unrealpak":
+                    mode = (
+                        action if action in {"list", "extract", "validate"} else "list"
+                    )
+                    dest = (
+                        None
+                        if action in {"list", "search", "validate"}
+                        else dest_for(path, suf)
+                    )
+                    argv = build_unrealpak_cmd(
+                        self._unrealpak(),
+                        path,
+                        mode,
+                        dest,
+                        self.pak_filter.text().strip() or None,
+                    )
+                    return Task("proc", action, path, dest, None, argv)
+                if kind == "iostore":
+                    mode = (
+                        action if action in {"list", "extract", "validate"} else "list"
+                    )
+                    dest = (
+                        None
+                        if action in {"list", "search", "validate"}
+                        else dest_for(path, suf)
+                    )
+                    argv = build_iostore_cmd(self._iostore(), path, mode, dest)
+                    return Task("proc", action, path, dest, None, argv)
+                tkind = "zip"
+                dest = (
+                    None
+                    if action in {"list", "search", "validate"}
+                    else dest_for(path, suf)
+                )
+                return Task(tkind, action, path, dest, None)
+        self._log("No file selected")
+        return None

--- a/aegis/ui/widgets/pak_iostore/utils.py
+++ b/aegis/ui/widgets/pak_iostore/utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+
+def dest_for(src: Path, suffix: str) -> Path:
+    """Return ``src`` with ``suffix`` appended before the extension."""
+    return src.with_name(src.stem + suffix)
+
+
+def build_unrealpak_cmd(
+    exe: str,
+    pak: Path,
+    mode: str,
+    dest: Optional[Path] = None,
+    filt: Optional[str] = None,
+) -> List[str]:
+    """Construct an UnrealPak command."""
+    cmd = [exe or "UnrealPak.exe", str(pak)]
+    if mode == "list":
+        cmd.append("-List")
+    elif mode == "extract" and dest:
+        cmd += ["-Extract", str(dest)]
+    if filt:
+        cmd.append(f'-Filter="{filt}"')
+    return cmd
+
+
+def build_iostore_cmd(
+    exe: str,
+    utoc: Path,
+    mode: str,
+    dest: Optional[Path] = None,
+) -> List[str]:
+    """Construct an IoStoreUtilities command."""
+    cmd = [exe or "IoStoreUtilities.exe"]
+    if mode == "list":
+        cmd += ["-List", f"-Container={utoc}"]
+    elif mode == "extract" and dest:
+        cmd += ["-Extract", f"-Container={utoc}", f"-OutputDir={dest}"]
+    return cmd

--- a/aegis/ui/widgets/pak_iostore/utils.py
+++ b/aegis/ui/widgets/pak_iostore/utils.py
@@ -18,10 +18,12 @@ def build_unrealpak_cmd(
 ) -> List[str]:
     """Construct an UnrealPak command."""
     cmd = [exe or "UnrealPak.exe", str(pak)]
-    if mode == "list":
+    if mode == "list" or mode == "search":
         cmd.append("-List")
     elif mode == "extract" and dest:
         cmd += ["-Extract", str(dest)]
+    elif mode == "validate":
+        cmd.append("-Test")
     if filt:
         cmd.append(f'-Filter="{filt}"')
     return cmd
@@ -35,8 +37,28 @@ def build_iostore_cmd(
 ) -> List[str]:
     """Construct an IoStoreUtilities command."""
     cmd = [exe or "IoStoreUtilities.exe"]
-    if mode == "list":
+    if mode == "list" or mode == "search":
         cmd += ["-List", f"-Container={utoc}"]
     elif mode == "extract" and dest:
         cmd += ["-Extract", f"-Container={utoc}", f"-OutputDir={dest}"]
+    elif mode == "validate":
+        cmd += ["-Validate", f"-Container={utoc}"]
     return cmd
+
+
+def compare_dirs(a: Path, b: Path) -> tuple[set[str], set[str], set[str]]:
+    """Return sets of relative paths only in ``a``, only in ``b``, and differing."""
+    from filecmp import dircmp
+
+    def _collect(dcmp: dircmp, prefix: str = "") -> tuple[set[str], set[str], set[str]]:
+        only_a = {prefix + name for name in dcmp.left_only}
+        only_b = {prefix + name for name in dcmp.right_only}
+        diff = {prefix + name for name in dcmp.diff_files}
+        for name, sub in dcmp.subdirs.items():
+            sa, sb, sd = _collect(sub, prefix + name + "/")
+            only_a.update(sa)
+            only_b.update(sb)
+            diff.update(sd)
+        return only_a, only_b, diff
+
+    return _collect(dircmp(a, b))

--- a/aegis/ui/widgets/pak_iostore/worker.py
+++ b/aegis/ui/widgets/pak_iostore/worker.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import shlex
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from PySide6.QtCore import QObject, QProcess, QTimer
+
+from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+
+
+@dataclass
+class Task:
+    """Discrete unit of work."""
+
+    type: str  # 'proc' or 'zip'
+    action: str  # 'list' or 'extract'
+    src: Path
+    dest: Optional[Path]
+    row: Optional[int]
+    argv: Optional[List[str]] = None
+
+
+class PakWorker(QObject):
+    """Sequential task runner for Pak/IoStore operations."""
+
+    def __init__(
+        self,
+        log_cb: Callable[[str], None],
+        preview_cb: Callable[[str], None],
+        unrealpak_path: Callable[[], str],
+        iostore_path: Callable[[], str],
+        pak_filter: Callable[[], str],
+        unzip_extract_enabled: Callable[[], bool],
+        row_status_cb: Callable[[int, str], None],
+        state_cb: Callable[[], None],
+    ) -> None:
+        super().__init__()
+        self.log_cb = log_cb
+        self.preview_cb = preview_cb
+        self.unrealpak_path = unrealpak_path
+        self.iostore_path = iostore_path
+        self.pak_filter = pak_filter
+        self.unzip_extract_enabled = unzip_extract_enabled
+        self.row_status_cb = row_status_cb
+        self.state_cb = state_cb
+        self.tasks: List[Task] = []
+        self.current: Optional[Task] = None
+        self.proc: Optional[QProcess] = None
+
+    # public API ---------------------------------------------------------
+    def enqueue(self, items: List[Task]) -> None:
+        if not items:
+            return
+        self.tasks.extend(items)
+        if not self.proc:
+            self._run_next()
+        self.state_cb()
+
+    def is_busy(self) -> bool:
+        return self.proc is not None or bool(self.tasks)
+
+    def status(self) -> tuple[int, int]:
+        running = 1 if self.proc else 0
+        return running, len(self.tasks)
+
+    # internals ----------------------------------------------------------
+    def _run_next(self) -> None:
+        if self.proc or not self.tasks:
+            return
+        task = self.tasks.pop(0)
+        self.current = task
+        if task.row is not None:
+            self.row_status_cb(task.row, "Running")
+        if task.type == "proc" and task.argv:
+            self.preview_cb(shlex.join(task.argv))
+            program, *args = task.argv
+            self.proc = QProcess()
+            self.proc.setProcessChannelMode(QProcess.MergedChannels)
+            self.proc.setProgram(program)
+            self.proc.setArguments(args)
+            self.proc.readyReadStandardOutput.connect(self._on_proc_output)
+            self.proc.readyReadStandardError.connect(self._on_proc_output)
+            self.proc.finished.connect(self._on_proc_finished)
+            self.proc.start()
+        elif task.type == "zip":
+            QTimer.singleShot(0, lambda: self._run_zip(task))
+        else:
+            self._finish_task(1)
+
+    def _on_proc_output(self) -> None:
+        if not self.proc:
+            return
+        data = self.proc.readAllStandardOutput().data().decode(errors="ignore")
+        if data:
+            self.log_cb(data.rstrip())
+
+    def _on_proc_finished(self, code: int, _status: QProcess.ExitStatus) -> None:
+        self._finish_task(code)
+
+    def _run_zip(self, task: Task) -> None:
+        self.preview_cb(f"zipfile {task.action} {task.src}")
+        try:
+            with zipfile.ZipFile(task.src) as zf:
+                if task.action == "list":
+                    for name in zf.namelist():
+                        self.log_cb(name)
+                    code = 0
+                else:
+                    dest = task.dest
+                    assert dest is not None
+                    dest.mkdir(parents=True, exist_ok=True)
+                    for name in zf.namelist():
+                        self.log_cb(name)
+                    zf.extractall(dest)
+                    code = 0
+                    if self.unzip_extract_enabled():
+                        new_tasks = self._scan_path_for_tasks(dest)
+                        self.tasks = new_tasks + self.tasks
+        except Exception as exc:  # pragma: no cover - unexpected
+            self.log_cb(str(exc))
+            code = 1
+        self._finish_task(code)
+
+    def _scan_path_for_tasks(self, root: Path) -> List[Task]:
+        tasks: List[Task] = []
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            ext = p.suffix.lower()
+            if ext == ".pak":
+                dest = dest_for(p, "_extracted")
+                argv = build_unrealpak_cmd(
+                    self.unrealpak_path(), p, "extract", dest, self.pak_filter() or None
+                )
+                tasks.append(Task("proc", "extract", p, dest, None, argv))
+            elif ext == ".utoc":
+                dest = dest_for(p, "_extracted")
+                argv = build_iostore_cmd(self.iostore_path(), p, "extract", dest)
+                tasks.append(Task("proc", "extract", p, dest, None, argv))
+        return tasks
+
+    def _finish_task(self, code: int) -> None:
+        if self.current and self.current.row is not None:
+            status = "Done" if code == 0 else f"Error {code}"
+            self.row_status_cb(self.current.row, status)
+        self.log_cb(f"exit code {code}")
+        self.proc = None
+        self.current = None
+        self._run_next()
+        self.state_cb()

--- a/aegis/ui/widgets/pak_iostore/worker.py
+++ b/aegis/ui/widgets/pak_iostore/worker.py
@@ -8,15 +8,15 @@ from typing import Callable, List, Optional
 
 from PySide6.QtCore import QObject, QProcess, QTimer
 
-from .utils import build_iostore_cmd, build_unrealpak_cmd, dest_for
+from .utils import build_iostore_cmd, build_unrealpak_cmd, compare_dirs, dest_for
 
 
 @dataclass
 class Task:
     """Discrete unit of work."""
 
-    type: str  # 'proc' or 'zip'
-    action: str  # 'list' or 'extract'
+    type: str  # 'proc', 'zip', or 'cmp'
+    action: str  # 'list', 'extract', 'validate', 'search', 'compare'
     src: Path
     dest: Optional[Path]
     row: Optional[int]
@@ -87,6 +87,8 @@ class PakWorker(QObject):
             self.proc.start()
         elif task.type == "zip":
             QTimer.singleShot(0, lambda: self._run_zip(task))
+        elif task.type == "cmp":
+            QTimer.singleShot(0, lambda: self._run_compare(task))
         else:
             self._finish_task(1)
 
@@ -95,7 +97,13 @@ class PakWorker(QObject):
             return
         data = self.proc.readAllStandardOutput().data().decode(errors="ignore")
         if data:
-            self.log_cb(data.rstrip())
+            if self.current and self.current.action == "search":
+                term = self.pak_filter()
+                for line in data.splitlines():
+                    if term in line:
+                        self.log_cb(line)
+            else:
+                self.log_cb(data.rstrip())
 
     def _on_proc_finished(self, code: int, _status: QProcess.ExitStatus) -> None:
         self._finish_task(code)
@@ -104,15 +112,22 @@ class PakWorker(QObject):
         self.preview_cb(f"zipfile {task.action} {task.src}")
         try:
             with zipfile.ZipFile(task.src) as zf:
-                if task.action == "list":
-                    for name in zf.namelist():
+                names = zf.namelist()
+                if task.action in {"list", "validate"}:
+                    for name in names:
                         self.log_cb(name)
+                    code = 0
+                elif task.action == "search":
+                    filt = self.pak_filter()
+                    for name in names:
+                        if filt in name:
+                            self.log_cb(name)
                     code = 0
                 else:
                     dest = task.dest
                     assert dest is not None
                     dest.mkdir(parents=True, exist_ok=True)
-                    for name in zf.namelist():
+                    for name in names:
                         self.log_cb(name)
                     zf.extractall(dest)
                     code = 0
@@ -123,6 +138,18 @@ class PakWorker(QObject):
             self.log_cb(str(exc))
             code = 1
         self._finish_task(code)
+
+    def _run_compare(self, task: Task) -> None:
+        assert task.dest is not None
+        self.preview_cb(f"compare {task.src} {task.dest}")
+        only_a, only_b, diff = compare_dirs(task.src, task.dest)
+        for p in sorted(only_a):
+            self.log_cb(f"only in {task.src}: {p}")
+        for p in sorted(only_b):
+            self.log_cb(f"only in {task.dest}: {p}")
+        for p in sorted(diff):
+            self.log_cb(f"different: {p}")
+        self._finish_task(0)
 
     def _scan_path_for_tasks(self, root: Path) -> List[Task]:
         tasks: List[Task] = []

--- a/aegis/ui/widgets/pak_iostore_panel.py
+++ b/aegis/ui/widgets/pak_iostore_panel.py
@@ -1,0 +1,5 @@
+"""Backward-compatible import for PakIoStorePanel."""
+
+from .pak_iostore.panel import PakIoStorePanel
+
+__all__ = ["PakIoStorePanel"]

--- a/tests/test_layout_persistence.py
+++ b/tests/test_layout_persistence.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
+pytest.importorskip("PySide6")
 from PySide6.QtCore import QRect, QSettings
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QApplication, QWidget

--- a/tests/test_pak_iostore_panel.py
+++ b/tests/test_pak_iostore_panel.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from aegis.ui.widgets.pak_iostore.utils import (
     build_iostore_cmd,
     build_unrealpak_cmd,
+    compare_dirs,
     dest_for,
 )
 
@@ -53,4 +54,31 @@ def test_command_builders() -> None:
         f"-Container={utoc}",
         f"-OutputDir={dest}",
     ]
+    assert build_unrealpak_cmd("/path/UnrealPak.exe", pak, "validate") == [
+        "/path/UnrealPak.exe",
+        str(pak),
+        "-Test",
+    ]
+    assert build_iostore_cmd("/path/IoStoreUtilities.exe", utoc, "validate") == [
+        "/path/IoStoreUtilities.exe",
+        "-Validate",
+        f"-Container={utoc}",
+    ]
     assert dest_for(pak, "_extracted") == Path("/tmp/test_extracted")
+
+
+def test_compare_dirs(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "same.txt").write_text("hi")
+    (b / "same.txt").write_text("hi")
+    (a / "only_a.txt").write_text("a")
+    (b / "only_b.txt").write_text("b")
+    (a / "diff.txt").write_text("one")
+    (b / "diff.txt").write_text("two")
+    only_a, only_b, diff = compare_dirs(a, b)
+    assert only_a == {"only_a.txt"}
+    assert only_b == {"only_b.txt"}
+    assert diff == {"diff.txt"}

--- a/tests/test_pak_iostore_panel.py
+++ b/tests/test_pak_iostore_panel.py
@@ -1,0 +1,56 @@
+"""Tests for Pak/IoStore helpers."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from pathlib import Path
+
+from aegis.ui.widgets.pak_iostore.utils import (
+    build_iostore_cmd,
+    build_unrealpak_cmd,
+    dest_for,
+)
+
+
+def test_command_builders() -> None:
+    pak = Path("/tmp/test.pak")
+    utoc = Path("/tmp/sample.utoc")
+    dest = Path("/tmp/out")
+
+    assert build_unrealpak_cmd("/path/UnrealPak.exe", pak, "list") == [
+        "/path/UnrealPak.exe",
+        str(pak),
+        "-List",
+    ]
+    assert build_unrealpak_cmd("/path/UnrealPak.exe", pak, "extract", dest) == [
+        "/path/UnrealPak.exe",
+        str(pak),
+        "-Extract",
+        str(dest),
+    ]
+    assert build_unrealpak_cmd(
+        "/path/UnrealPak.exe",
+        pak,
+        "extract",
+        dest,
+        "*.uasset",
+    ) == [
+        "/path/UnrealPak.exe",
+        str(pak),
+        "-Extract",
+        str(dest),
+        '-Filter="*.uasset"',
+    ]
+    assert build_iostore_cmd("/path/IoStoreUtilities.exe", utoc, "list") == [
+        "/path/IoStoreUtilities.exe",
+        "-List",
+        f"-Container={utoc}",
+    ]
+    assert build_iostore_cmd("/path/IoStoreUtilities.exe", utoc, "extract", dest) == [
+        "/path/IoStoreUtilities.exe",
+        "-Extract",
+        f"-Container={utoc}",
+        f"-OutputDir={dest}",
+    ]
+    assert dest_for(pak, "_extracted") == Path("/tmp/test_extracted")


### PR DESCRIPTION
## Summary
- split Pak / IoStore panel into a modular package with reusable worker and utilities
- support UnrealPak file filtering via new input
- cover command builders with tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd29a6b0e88325b7669163ee2a5f6c