### PR TITLE
feat(commandlets): add commandlet runner panel

### DIFF
--- a/aegis/modules/commandlets.py
+++ b/aegis/modules/commandlets.py
@@ -1,0 +1,149 @@
+"""Utilities for building and saving Unreal commandlet runs."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import List
+
+DEFAULT_COMMANDLETS = [
+    "ResavePackages",
+    "FixupRedirects",
+    "AssetAudit",
+    "SizeMap",
+    "GatherText",
+]
+
+
+@dataclass
+class CommandletFlags:
+    """Common commandlet behavior flags."""
+
+    unattended: bool = True
+    nop4: bool = True
+    nullrhi: bool = False
+    stdout: bool = True
+    utf8: bool = True
+
+    def to_argv(self) -> List[str]:
+        argv: List[str] = []
+        if self.unattended:
+            argv.append("-unattended")
+        if self.nop4:
+            argv.append("-nop4")
+        if self.nullrhi:
+            argv.append("-NullRHI")
+        if self.stdout:
+            argv.append("-stdout")
+        if self.utf8:
+            argv.append("-UTF8Output")
+        return argv
+
+
+@dataclass
+class CommandletRecipe:
+    """Serializable recipe describing a commandlet invocation."""
+
+    commandlet: str = "ResavePackages"
+    packages: list[str] = field(default_factory=list)
+    maps: list[str] = field(default_factory=list)
+    collection: str = ""
+    extra_args: str = ""
+    flags: CommandletFlags = field(default_factory=CommandletFlags)
+    version: int = 1
+
+    def to_json(self) -> str:
+        data = asdict(self)
+        data["flags"] = asdict(self.flags)
+        return json.dumps(data, indent=2)
+
+    @staticmethod
+    def from_json(text: str) -> "CommandletRecipe":
+        data = json.loads(text)
+        flags = CommandletFlags(**data.get("flags", {}))
+        return CommandletRecipe(
+            commandlet=data.get("commandlet", "ResavePackages"),
+            packages=data.get("packages", []),
+            maps=data.get("maps", []),
+            collection=data.get("collection", ""),
+            extra_args=data.get("extra_args", ""),
+            flags=flags,
+        )
+
+
+def build_argv(exe: Path, project: Path, recipe: CommandletRecipe) -> List[str]:
+    """Compose the argv list for a commandlet run."""
+
+    argv: List[str] = [str(exe), str(project), f"-run={recipe.commandlet}"]
+    argv.extend(recipe.flags.to_argv())
+    for token in recipe.packages:
+        if token:
+            argv.append(f'-Package="{token}"')
+    for token in recipe.maps:
+        if token:
+            argv.append(f"-Map={token}")
+    if recipe.collection:
+        argv.append(f"-Collection={recipe.collection}")
+    if recipe.extra_args:
+        argv.extend(shlex.split(recipe.extra_args))
+    return argv
+
+
+def preview_command(argv: List[str]) -> str:
+    """Return a shell-escaped command preview."""
+
+    return shlex.join(argv)
+
+
+def recipes_dir(uproject: Path) -> Path:
+    """Return the directory for commandlet recipes."""
+
+    return uproject.parent / ".aegies" / "recipes" / "commandlets"
+
+
+def save_recipe(uproject: Path, name: str, recipe: CommandletRecipe) -> Path:
+    """Write ``recipe`` to ``name`` under the project's recipes directory."""
+
+    dir_path = recipes_dir(uproject)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    file_path = dir_path / f"{name}.json"
+    file_path.write_text(recipe.to_json(), encoding="utf-8")
+    return file_path
+
+
+def load_recipe(path: Path) -> CommandletRecipe:
+    """Load a commandlet recipe from ``path``."""
+
+    return CommandletRecipe.from_json(path.read_text(encoding="utf-8"))
+
+
+def custom_cmdlets_file(uproject: Path) -> Path:
+    """Return path to the custom commandlets list."""
+
+    return uproject.parent / ".aegies" / "commandlets.json"
+
+
+def load_custom_cmdlets(uproject: Path) -> list[str]:
+    """Load custom commandlets for ``uproject``."""
+
+    path = custom_cmdlets_file(uproject)
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return list(data.get("commandlets", []))
+
+
+def add_custom_cmdlet(uproject: Path, name: str) -> list[str]:
+    """Append ``name`` to the custom commandlets file for ``uproject``."""
+
+    cmdlets = load_custom_cmdlets(uproject)
+    if name not in cmdlets:
+        cmdlets.append(name)
+        path = custom_cmdlets_file(uproject)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"commandlets": cmdlets}, indent=2), encoding="utf-8"
+        )
+    return cmdlets

--- a/aegis/ui/init_tabs.py
+++ b/aegis/ui/init_tabs.py
@@ -14,6 +14,7 @@ from aegis.ui.widgets.env_doc import EnvDocPanel
 from aegis.ui.widgets.profile_info_bar import ProfileInfoBar
 from aegis.ui.widgets.uaft_panel import UaftPanel
 from aegis.ui.widgets.pak_iostore_panel import PakIoStorePanel
+from aegis.ui.widgets.commandlet_runner_widget import CommandletRunnerWidget
 
 
 @dataclass
@@ -27,6 +28,7 @@ class TabSetup:
     build_tabs: QTabWidget
     uaft_panel: UaftPanel
     pak_panel: PakIoStorePanel
+    commandlet_runner: CommandletRunnerWidget
 
 
 def init_tabs(runner: TaskRunner, log_cb: Callable[[str, str], None]) -> TabSetup:
@@ -54,10 +56,11 @@ def init_tabs(runner: TaskRunner, log_cb: Callable[[str, str], None]) -> TabSetu
     uaft_layout.addWidget(uaft_panel, 1)
 
     pak_panel = PakIoStorePanel()
+    cmd_panel = CommandletRunnerWidget(runner, log_cb)
 
     tabs.addTab(env_container, "EnvDoc")
     tabs.addTab(build_container, "Build")
-    tabs.addTab(QTextEdit("Commandlets (stub)"), "Commandlets")
+    tabs.addTab(cmd_panel, "Commandlets")
     tabs.addTab(pak_panel, "Pak / IoStore")
     tabs.addTab(uaft_container, "Devices / UAFT")
     tabs.addTab(QTextEdit("Tests (stub)"), "Tests")
@@ -79,4 +82,5 @@ def init_tabs(runner: TaskRunner, log_cb: Callable[[str, str], None]) -> TabSetu
         build_tabs=build_tabs,
         uaft_panel=uaft_panel,
         pak_panel=pak_panel,
+        commandlet_runner=cmd_panel,
     )

--- a/aegis/ui/widgets/commandlet_runner_groups.py
+++ b/aegis/ui/widgets/commandlet_runner_groups.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from aegis.modules.commandlets import DEFAULT_COMMANDLETS
+
+
+@dataclass
+class PathsGroup:
+    box: QGroupBox
+    exe_le: QLineEdit
+    proj_le: QLineEdit
+
+
+def create_paths_group(browse_cb: Callable[[QLineEdit, bool], None]) -> PathsGroup:
+    exe_le = QLineEdit()
+    exe_le.setObjectName("exe_le")
+    proj_le = QLineEdit()
+    proj_le.setObjectName("uproject_le")
+    btn_exe = QPushButton("Browse…")
+    btn_exe.clicked.connect(lambda: browse_cb(exe_le, False))
+    btn_proj = QPushButton("Browse…")
+    btn_proj.clicked.connect(lambda: browse_cb(proj_le, True))
+
+    def _col(label: str, le: QLineEdit, btn: QPushButton) -> QVBoxLayout:
+        row = QHBoxLayout()
+        row.addWidget(le)
+        row.addWidget(btn)
+        col = QVBoxLayout()
+        col.addWidget(QLabel(label))
+        col.addLayout(row)
+        return col
+
+    row = QHBoxLayout()
+    row.addLayout(_col("UnrealEditor-Cmd.exe", exe_le, btn_exe))
+    row.addLayout(_col("Project", proj_le, btn_proj))
+    box = QGroupBox("Paths & Target")
+    box.setLayout(row)
+    return PathsGroup(box, exe_le, proj_le)
+
+
+@dataclass
+class ScopeGroup:
+    box: QGroupBox
+    cmdlet_cb: QComboBox
+    add_btn: QPushButton
+    packages_le: QLineEdit
+    maps_le: QLineEdit
+    collection_le: QLineEdit
+
+
+def create_scope_group(add_cb: Callable[[], None]) -> ScopeGroup:
+    cmdlet_cb = QComboBox()
+    cmdlet_cb.addItems(DEFAULT_COMMANDLETS)
+    cmdlet_cb.setObjectName("cmdlet_cb")
+    add_btn = QPushButton("Add…")
+    add_btn.clicked.connect(add_cb)
+    row_cmd = QHBoxLayout()
+    row_cmd.addWidget(cmdlet_cb)
+    row_cmd.addWidget(add_btn)
+    packages_le = QLineEdit()
+    maps_le = QLineEdit()
+    collection_le = QLineEdit()
+    form = QFormLayout()
+    form.addRow("Commandlet:", row_cmd)
+    form.addRow("Packages/Paths (;)", packages_le)
+    form.addRow("Maps (;)", maps_le)
+    form.addRow("Collection", collection_le)
+    box = QGroupBox("Commandlet & Scope")
+    box.setLayout(form)
+    return ScopeGroup(box, cmdlet_cb, add_btn, packages_le, maps_le, collection_le)
+
+
+@dataclass
+class FlagsGroup:
+    box: QGroupBox
+    flag_unatt: QCheckBox
+    flag_nop4: QCheckBox
+    flag_nullrhi: QCheckBox
+    flag_stdout: QCheckBox
+    flag_utf8: QCheckBox
+    extra_le: QLineEdit
+
+
+def create_flags_group() -> FlagsGroup:
+    flag_unatt = QCheckBox("-unattended")
+    flag_unatt.setChecked(True)
+    flag_nop4 = QCheckBox("-nop4")
+    flag_nop4.setChecked(True)
+    flag_nullrhi = QCheckBox("-NullRHI")
+    flag_stdout = QCheckBox("-stdout")
+    flag_stdout.setChecked(True)
+    flag_utf8 = QCheckBox("-UTF8Output")
+    flag_utf8.setChecked(True)
+    extra_le = QLineEdit()
+    grid = QGridLayout()
+    cbs = (flag_unatt, flag_nop4, flag_nullrhi, flag_stdout, flag_utf8)
+    for i, cb in enumerate(cbs):
+        grid.addWidget(cb, i // 3, i % 3)
+    row_extra = QHBoxLayout()
+    row_extra.addWidget(QLabel("Extra Args"))
+    row_extra.addWidget(extra_le)
+    box = QGroupBox("Behavior Flags")
+    lay = QVBoxLayout(box)
+    lay.addLayout(grid)
+    lay.addLayout(row_extra)
+    return FlagsGroup(
+        box,
+        flag_unatt,
+        flag_nop4,
+        flag_nullrhi,
+        flag_stdout,
+        flag_utf8,
+        extra_le,
+    )
+
+
+@dataclass
+class RunControls:
+    box: QGroupBox
+    preview_le: QLineEdit
+    dry_run_btn: QPushButton
+    run_btn: QPushButton
+    stop_btn: QPushButton
+
+
+def create_run_controls(
+    copy_cb: Callable[[], None],
+    dry_cb: Callable[[], None],
+    run_cb: Callable[[], None],
+    stop_cb: Callable[[], None],
+) -> RunControls:
+    preview_le = QLineEdit()
+    preview_le.setReadOnly(True)
+    preview_le.setObjectName("preview_le")
+    btn_copy = QPushButton("Copy")
+    btn_copy.clicked.connect(copy_cb)
+    dry_btn = QPushButton("Dry Run")
+    dry_btn.clicked.connect(dry_cb)
+    run_btn = QPushButton("Run")
+    run_btn.clicked.connect(run_cb)
+    stop_btn = QPushButton("Stop")
+    stop_btn.clicked.connect(stop_cb)
+    stop_btn.setEnabled(False)
+    row_prev = QHBoxLayout()
+    row_prev.addWidget(preview_le, 1)
+    row_prev.addWidget(btn_copy)
+    row_run = QHBoxLayout()
+    row_run.addWidget(dry_btn)
+    row_run.addWidget(run_btn)
+    row_run.addWidget(stop_btn)
+    box = QGroupBox("Run Controls")
+    lay = QVBoxLayout(box)
+    lay.addLayout(row_prev)
+    lay.addLayout(row_run)
+    return RunControls(box, preview_le, dry_btn, run_btn, stop_btn)
+
+
+@dataclass
+class RecipeGroup:
+    box: QGroupBox
+    save_btn: QPushButton
+    load_btn: QPushButton
+
+
+def create_recipe_group(
+    save_cb: Callable[[], None],
+    load_cb: Callable[[], None],
+) -> RecipeGroup:
+    save_btn = QPushButton("Save Recipe…")
+    save_btn.clicked.connect(save_cb)
+    load_btn = QPushButton("Load Recipe…")
+    load_btn.clicked.connect(load_cb)
+    row = QHBoxLayout()
+    row.addWidget(save_btn)
+    row.addWidget(load_btn)
+    box = QGroupBox("Recipes")
+    lay = QVBoxLayout(box)
+    lay.addLayout(row)
+    return RecipeGroup(box, save_btn, load_btn)

--- a/aegis/ui/widgets/commandlet_runner_state.py
+++ b/aegis/ui/widgets/commandlet_runner_state.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from .commandlet_runner_groups import FlagsGroup, ScopeGroup
+from aegis.modules.commandlets import CommandletFlags, CommandletRecipe
+
+
+def recipe_from_inputs(scope: ScopeGroup, flags: FlagsGroup) -> CommandletRecipe:
+    flags_obj = CommandletFlags(
+        unattended=flags.flag_unatt.isChecked(),
+        nop4=flags.flag_nop4.isChecked(),
+        nullrhi=flags.flag_nullrhi.isChecked(),
+        stdout=flags.flag_stdout.isChecked(),
+        utf8=flags.flag_utf8.isChecked(),
+    )
+    return CommandletRecipe(
+        commandlet=scope.cmdlet_cb.currentText(),
+        packages=[p for p in scope.packages_le.text().split(";") if p],
+        maps=[m for m in scope.maps_le.text().split(";") if m],
+        collection=scope.collection_le.text().strip(),
+        extra_args=flags.extra_le.text().strip(),
+        flags=flags_obj,
+    )
+
+
+def apply_recipe_to_inputs(
+    recipe: CommandletRecipe, scope: ScopeGroup, flags: FlagsGroup
+) -> None:
+    scope.cmdlet_cb.setCurrentText(recipe.commandlet)
+    for le, text in [
+        (scope.packages_le, ";".join(recipe.packages)),
+        (scope.maps_le, ";".join(recipe.maps)),
+        (scope.collection_le, recipe.collection),
+        (flags.extra_le, recipe.extra_args),
+    ]:
+        le.setText(text)
+    for cb, state in [
+        (flags.flag_unatt, recipe.flags.unattended),
+        (flags.flag_nop4, recipe.flags.nop4),
+        (flags.flag_nullrhi, recipe.flags.nullrhi),
+        (flags.flag_stdout, recipe.flags.stdout),
+        (flags.flag_utf8, recipe.flags.utf8),
+    ]:
+        cb.setChecked(state)

--- a/aegis/ui/widgets/commandlet_runner_widget.py
+++ b/aegis/ui/widgets/commandlet_runner_widget.py
@@ -1,0 +1,180 @@
+"""Panel for running Unreal commandlets with previews and recipes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import QFileDialog, QInputDialog, QLineEdit, QVBoxLayout, QWidget
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.modules.commandlets import (
+    DEFAULT_COMMANDLETS,
+    add_custom_cmdlet,
+    build_argv,
+    load_custom_cmdlets,
+    load_recipe,
+    preview_command,
+    recipes_dir,
+    save_recipe,
+)
+from . import commandlet_runner_groups as crg
+from .commandlet_runner_state import apply_recipe_to_inputs, recipe_from_inputs
+
+
+class CommandletRunnerWidget(QWidget):
+    def __init__(
+        self,
+        runner: TaskRunner,
+        log_cb: Callable[[str, str], None],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.runner = runner
+        self.log = log_cb
+        self.profile: Profile | None = None
+
+        self.paths: crg.PathsGroup = crg.create_paths_group(self._browse)
+        self.scope: crg.ScopeGroup = crg.create_scope_group(self._add_cmdlet)
+        self.flags: crg.FlagsGroup = crg.create_flags_group()
+        self.controls: crg.RunControls = crg.create_run_controls(
+            lambda: QGuiApplication.clipboard().setText(
+                self.controls.preview_le.text()
+            ),
+            self._refresh,
+            self._run,
+            self.runner.cancel,
+        )
+        self.recipes: crg.RecipeGroup = crg.create_recipe_group(
+            self._save_recipe, self._load_recipe
+        )
+
+        self.inputs = [
+            self.paths.exe_le,
+            self.paths.proj_le,
+            self.scope.cmdlet_cb,
+            self.scope.add_btn,
+            self.scope.packages_le,
+            self.scope.maps_le,
+            self.scope.collection_le,
+            self.flags.flag_unatt,
+            self.flags.flag_nop4,
+            self.flags.flag_nullrhi,
+            self.flags.flag_stdout,
+            self.flags.flag_utf8,
+            self.flags.extra_le,
+            self.recipes.save_btn,
+            self.recipes.load_btn,
+            self.controls.dry_run_btn,
+            self.controls.run_btn,
+        ]
+
+        root = QVBoxLayout(self)
+        for box in (
+            self.paths.box,
+            self.scope.box,
+            self.flags.box,
+            self.controls.box,
+            self.recipes.box,
+        ):
+            root.addWidget(box)
+
+    def _browse(self, le: QLineEdit, uproject: bool = False) -> None:
+        if uproject:
+            path, _ = QFileDialog.getOpenFileName(
+                self, "Choose .uproject", str(Path.cwd()), "*.uproject"
+            )
+        else:
+            path, _ = QFileDialog.getOpenFileName(
+                self, "Choose UnrealEditor-Cmd.exe", str(Path.cwd())
+            )
+        if path:
+            le.setText(path)
+            if uproject:
+                self._load_custom_cmdlets()
+            self._build()
+
+    def _load_custom_cmdlets(self) -> None:
+        if self.paths.proj_le.text():
+            customs = load_custom_cmdlets(Path(self.paths.proj_le.text()))
+            self.scope.cmdlet_cb.clear()
+            self.scope.cmdlet_cb.addItems(DEFAULT_COMMANDLETS + customs)
+
+    def _add_cmdlet(self) -> None:
+        if not self.paths.proj_le.text():
+            return
+        name, ok = QInputDialog.getText(self, "Add Commandlet", "Name:")
+        if ok and name:
+            add_custom_cmdlet(Path(self.paths.proj_le.text()), name)
+            self._load_custom_cmdlets()
+            self.scope.cmdlet_cb.setCurrentText(name)
+
+    def _build(self) -> list[str]:
+        argv = build_argv(
+            Path(self.paths.exe_le.text()),
+            Path(self.paths.proj_le.text()),
+            recipe_from_inputs(self.scope, self.flags),
+        )
+        self.controls.preview_le.setText(preview_command(argv))
+        return argv
+
+    def _refresh(self) -> None:
+        self._build()
+
+    def _run(self) -> None:
+        argv = self._build()
+        self._toggle(True)
+        self.runner.start(
+            argv,
+            lambda line: self.log(line, "info"),
+            lambda line: self.log(line, "error"),
+            self._finished,
+        )
+
+    def _finished(self, code: int) -> None:
+        self.log(f"Commandlet exited {code}", "info")
+        self._toggle(False)
+
+    def _toggle(self, running: bool) -> None:
+        for w in self.inputs:
+            w.setEnabled(not running)
+        self.controls.stop_btn.setEnabled(running)
+
+    def _save_recipe(self) -> None:
+        if not self.paths.proj_le.text():
+            return
+        name, ok = QInputDialog.getText(
+            self, "Recipe Name", "Filename (without .json):"
+        )
+        if ok and name:
+            save_recipe(
+                Path(self.paths.proj_le.text()),
+                name,
+                recipe_from_inputs(self.scope, self.flags),
+            )
+
+    def _load_recipe(self) -> None:
+        if not self.paths.proj_le.text():
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Recipe",
+            str(recipes_dir(Path(self.paths.proj_le.text()))),
+            "*.json",
+        )
+        if path:
+            apply_recipe_to_inputs(load_recipe(Path(path)), self.scope, self.flags)
+            self._build()
+
+    def update_profile(self, profile: Profile | None) -> None:
+        self.profile = profile
+        if profile:
+            exe = profile.engine_root / "Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
+            self.paths.exe_le.setText(str(exe))
+            for p in profile.project_dir.glob("*.uproject"):
+                self.paths.proj_le.setText(str(p))
+                break
+            self._load_custom_cmdlets()
+            self._build()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ stay decoupled and easy to extend.
   subprocess task runner
 - `aegis/modules/` – wrappers for individual Unreal command‑line tools
 - `aegis/ui/` – Qt widgets, pages, and themes
-- `docs/` – developer documentation
+- `docs/` – developer documentation (see `commandlet_runner.md` for the Commandlet Runner design)
 - `tests/` – unit and functional tests
 
 ## Core

--- a/docs/commandlet_runner.md
+++ b/docs/commandlet_runner.md
@@ -1,0 +1,67 @@
+# Commandlet Runner
+
+A dockable panel that turns Unreal commandlets into one-click actions with a copyable CLI preview and streamed logs.
+
+## Goals & Scope
+- Launch `UnrealEditor-Cmd.exe` against a chosen `.uproject`.
+- Provide JSON recipes for repeatable runs.
+- Filter scope by packages, paths, collections, or maps.
+- Remain engine-agnostic by only invoking official tools.
+- Make commands and output copyable and auditable.
+
+## UI Layout
+1. **Paths & Target**
+   - Browse and validate paths to `UnrealEditor-Cmd.exe` and the target project.
+2. **Commandlet & Scope**
+   - Dropdown of common commandlets (ResavePackages, FixupRedirects, AssetAudit, SizeMap, GatherText) with project-specific additions stored in `<uproject>/.aegies/commandlets.json` via an **Add…** button.
+   - Inputs for packages/paths, collections, and maps with wildcard support.
+3. **Behavior Flags**
+   - Common toggles: `-unattended`, `-nop4`, `-NullRHI`, `-stdout`, `-UTF8Output`.
+   - Free-form extra arguments appended verbatim.
+4. **Run Controls**
+   - **Dry Run** – compose and show the final CLI without executing.
+   - **Run** – execute using `QProcess` and stream merged stdout/stderr.
+   - **Stop** – attempt graceful termination, then force-kill if needed.
+5. **Observability**
+   - Read-only command preview with copy button.
+   - Output streams to the main log panel with search and filtering.
+6. **Recipes**
+   - Save/load JSON recipes at `<uproject>/.aegies/recipes/commandlets/*.json`.
+   - Auto-save last used settings per profile.
+
+## Command Construction
+The runner composes conservative argv lists:
+
+```
+UnrealEditor-Cmd.exe "<Project.uproject>" -run=<Commandlet> -unattended -nop4 -UTF8Output
+```
+
+Scope options:
+- `-Package="/Game/MyPath"` for each package or path token.
+- `-Map=<MapAsset>` for each map.
+- `-Collection=<Name>` for collection filters.
+- Extra arguments supplied verbatim.
+
+## Architecture & Data Flow
+1. **Validation** – ensure paths exist and at least one scope option is set when required.
+2. **Command Builder** – build an argv list and populate the preview command.
+3. **Execution** – run with `QProcess`, `MergedChannels`, and stream log output.
+4. **Logging & Export** – record stdout/stderr and final argv in the task transcript.
+5. **Profiles & Recipes** – defaults from the active profile with shareable recipe files.
+
+## Guardrails
+- Never use `shell=True`.
+- Show reminders for operations that modify content.
+- Disable inputs while a run is active.
+- Dry-run preview must match the executable argv exactly.
+
+## Failure Modes & Fixes
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| `UnrealEditor-Cmd.exe` not found | Wrong engine path | Point to `Engine/Binaries/Win64/UnrealEditor-Cmd.exe` |
+| Exit code non-zero with missing modules | Project or plug-in not compiled | Rebuild the editor target and verify plug-ins |
+| "No assets matched scope" | Bad `-Package`/`-Map` patterns | Use absolute `/Game/...` paths or broaden scope |
+| Editor tries to open UI | Missing `-unattended` or `-NullRHI` | Keep both toggles enabled for headless runs |
+| Hangs on Perforce dialog | P4 integration active | Use `-nop4` or disconnect Perforce |
+| Unicode garbling | Code page mismatch | Add `-UTF8Output` and decode as UTF-8 |
+

--- a/tests/test_commandlets.py
+++ b/tests/test_commandlets.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from aegis.modules.commandlets import (
+    CommandletFlags,
+    CommandletRecipe,
+    add_custom_cmdlet,
+    build_argv,
+    load_custom_cmdlets,
+    load_recipe,
+    save_recipe,
+)
+
+
+def test_build_argv_basic(tmp_path: Path) -> None:
+    exe = tmp_path / "UnrealEditor-Cmd.exe"
+    exe.write_text("", encoding="utf-8")
+    proj = tmp_path / "Game.uproject"
+    proj.write_text("", encoding="utf-8")
+    recipe = CommandletRecipe(packages=["/Game/Maps"])  # defaults ResavePackages
+    argv = build_argv(exe, proj, recipe)
+    assert argv[:3] == [str(exe), str(proj), "-run=ResavePackages"]
+    assert '-Package="/Game/Maps"' in argv
+
+
+def test_recipe_roundtrip(tmp_path: Path) -> None:
+    proj = tmp_path / "Game.uproject"
+    proj.write_text("", encoding="utf-8")
+    recipe = CommandletRecipe(
+        commandlet="FixupRedirects",
+        packages=["/Game/*"],
+        maps=["/Game/Map"],
+        collection="MyCollection",
+        extra_args="-AllowPlugins",
+        flags=CommandletFlags(nullrhi=True, stdout=False),
+    )
+    path = save_recipe(proj, "sample", recipe)
+    loaded = load_recipe(path)
+    assert loaded == recipe
+
+
+def test_custom_cmdlets(tmp_path: Path) -> None:
+    proj = tmp_path / "Game.uproject"
+    proj.write_text("", encoding="utf-8")
+    assert load_custom_cmdlets(proj) == []
+    add_custom_cmdlet(proj, "MyCmdlet")
+    assert load_custom_cmdlets(proj) == ["MyCmdlet"]

--- a/tests/test_init_tabs.py
+++ b/tests/test_init_tabs.py
@@ -16,3 +16,4 @@ def test_init_tabs_creates_tabs(qtbot) -> None:
     setup = init_tabs(TaskRunner(), _noop_log)
     qtbot.addWidget(setup.central)
     assert setup.tabs.count() == 7
+    assert setup.commandlet_runner is not None


### PR DESCRIPTION
## Summary
- integrate project-specific custom commandlets stored in `.aegies/commandlets.json`
- display UnrealEditor-Cmd.exe and project pickers side-by-side with horizontal-first flag layout
- refactor runner state helpers and tests to support custom commandlets

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd3fa9bdb48325977149349603a17d