### PR TITLE
feat(commandlets): persist custom commandlets

### DIFF
--- a/aegis/modules/commandlets.py
+++ b/aegis/modules/commandlets.py
@@ -9,6 +9,15 @@ from pathlib import Path
 from typing import List
 
 
+DEFAULT_COMMANDLETS = [
+    "ResavePackages",
+    "FixupRedirects",
+    "AssetAudit",
+    "SizeMap",
+    "GatherText",
+]
+
+
 @dataclass
 class CommandletFlags:
     """Common commandlet behavior flags."""
@@ -109,3 +118,38 @@ def load_recipe(path: Path) -> CommandletRecipe:
     """Load a commandlet recipe from ``path``."""
 
     return CommandletRecipe.from_json(path.read_text(encoding="utf-8"))
+
+
+def commandlets_file(uproject: Path) -> Path:
+    """Return the path storing custom commandlets for ``uproject``."""
+
+    return uproject.parent / ".aegies" / "commandlets.json"
+
+
+def load_commandlets(uproject: Path | None) -> list[str]:
+    """Return default commandlets plus any project-specific additions."""
+
+    cmds = list(DEFAULT_COMMANDLETS)
+    if not uproject:
+        return cmds
+    path = commandlets_file(uproject)
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                for cmd in data:
+                    if cmd not in cmds:
+                        cmds.append(cmd)
+        except json.JSONDecodeError:
+            pass
+    return cmds
+
+
+def save_commandlets(uproject: Path, commandlets: list[str]) -> Path:
+    """Persist custom commandlets for ``uproject``."""
+
+    path = commandlets_file(uproject)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    custom = [c for c in commandlets if c not in DEFAULT_COMMANDLETS]
+    path.write_text(json.dumps(sorted(custom), indent=2), encoding="utf-8")
+    return path

--- a/aegis/ui/widgets/commandlet_runner_groups.py
+++ b/aegis/ui/widgets/commandlet_runner_groups.py
@@ -7,20 +7,14 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFormLayout,
+    QGridLayout,
     QGroupBox,
     QHBoxLayout,
+    QLabel,
     QLineEdit,
     QPushButton,
     QVBoxLayout,
 )
-
-COMMANDLETS = [
-    "ResavePackages",
-    "FixupRedirects",
-    "AssetAudit",
-    "SizeMap",
-    "GatherText",
-]
 
 
 @dataclass
@@ -39,17 +33,15 @@ def create_paths_group(browse_cb: Callable[[QLineEdit, bool], None]) -> PathsGro
     btn_exe.clicked.connect(lambda: browse_cb(exe_le, False))
     btn_proj = QPushButton("Browse…")
     btn_proj.clicked.connect(lambda: browse_cb(proj_le, True))
-    re = QHBoxLayout()
-    re.addWidget(exe_le)
-    re.addWidget(btn_exe)
-    rp = QHBoxLayout()
-    rp.addWidget(proj_le)
-    rp.addWidget(btn_proj)
-    form = QFormLayout()
-    form.addRow("UnrealEditor-Cmd.exe:", re)
-    form.addRow("Project:", rp)
+    grid = QGridLayout()
+    grid.addWidget(QLabel("UnrealEditor-Cmd.exe:"), 0, 0)
+    grid.addWidget(exe_le, 0, 1)
+    grid.addWidget(btn_exe, 0, 2)
+    grid.addWidget(QLabel("Project:"), 0, 3)
+    grid.addWidget(proj_le, 0, 4)
+    grid.addWidget(btn_proj, 0, 5)
     box = QGroupBox("Paths & Target")
-    box.setLayout(form)
+    box.setLayout(grid)
     return PathsGroup(box, exe_le, proj_le)
 
 
@@ -57,26 +49,32 @@ def create_paths_group(browse_cb: Callable[[QLineEdit, bool], None]) -> PathsGro
 class ScopeGroup:
     box: QGroupBox
     cmdlet_cb: QComboBox
+    add_btn: QPushButton
     packages_le: QLineEdit
     maps_le: QLineEdit
     collection_le: QLineEdit
 
 
-def create_scope_group() -> ScopeGroup:
+def create_scope_group(commandlets: list[str]) -> ScopeGroup:
     cmdlet_cb = QComboBox()
-    cmdlet_cb.addItems(COMMANDLETS)
+    cmdlet_cb.addItems(commandlets)
     cmdlet_cb.setObjectName("cmdlet_cb")
+    add_btn = QPushButton("Add")
+    add_btn.setObjectName("add_cmdlet_btn")
+    row_cmdlet = QHBoxLayout()
+    row_cmdlet.addWidget(cmdlet_cb)
+    row_cmdlet.addWidget(add_btn)
     packages_le = QLineEdit()
     maps_le = QLineEdit()
     collection_le = QLineEdit()
     form = QFormLayout()
-    form.addRow("Commandlet:", cmdlet_cb)
+    form.addRow("Commandlet:", row_cmdlet)
     form.addRow("Packages/Paths (;)", packages_le)
     form.addRow("Maps (;)", maps_le)
     form.addRow("Collection", collection_le)
     box = QGroupBox("Commandlet & Scope")
     box.setLayout(form)
-    return ScopeGroup(box, cmdlet_cb, packages_le, maps_le, collection_le)
+    return ScopeGroup(box, cmdlet_cb, add_btn, packages_le, maps_le, collection_le)
 
 
 @dataclass
@@ -101,18 +99,16 @@ def create_flags_group() -> FlagsGroup:
     flag_utf8 = QCheckBox("-UTF8Output")
     flag_utf8.setChecked(True)
     extra_le = QLineEdit()
-    form = QFormLayout()
-    for cb in (
-        flag_unatt,
-        flag_nop4,
-        flag_nullrhi,
-        flag_stdout,
-        flag_utf8,
-    ):
-        form.addRow(cb)
-    form.addRow("Extra Args", extra_le)
+    grid = QGridLayout()
+    grid.addWidget(flag_unatt, 0, 0)
+    grid.addWidget(flag_nop4, 0, 1)
+    grid.addWidget(flag_nullrhi, 0, 2)
+    grid.addWidget(flag_stdout, 1, 0)
+    grid.addWidget(flag_utf8, 1, 1)
+    grid.addWidget(QLabel("Extra Args"), 2, 0)
+    grid.addWidget(extra_le, 2, 1, 1, 2)
     box = QGroupBox("Behavior Flags")
-    box.setLayout(form)
+    box.setLayout(grid)
     return FlagsGroup(
         box,
         flag_unatt,

--- a/aegis/ui/widgets/commandlet_runner_widget.py
+++ b/aegis/ui/widgets/commandlet_runner_widget.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import Callable
 
 from PySide6.QtGui import QGuiApplication
-from PySide6.QtWidgets import QFileDialog, QInputDialog, QLineEdit, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QInputDialog,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from aegis.core.profile import Profile
 from aegis.core.task_runner import TaskRunner
@@ -14,9 +20,11 @@ from aegis.modules.commandlets import (
     CommandletFlags,
     CommandletRecipe,
     build_argv,
+    load_commandlets,
     load_recipe,
     preview_command,
     recipes_dir,
+    save_commandlets,
     save_recipe,
 )
 from . import commandlet_runner_groups as crg
@@ -35,7 +43,8 @@ class CommandletRunnerWidget(QWidget):
         self.profile: Profile | None = None
 
         self.paths: crg.PathsGroup = crg.create_paths_group(self._browse)
-        self.scope: crg.ScopeGroup = crg.create_scope_group()
+        self.scope: crg.ScopeGroup = crg.create_scope_group(load_commandlets(None))
+        self.scope.add_btn.clicked.connect(self._add_cmdlet)
         self.flags: crg.FlagsGroup = crg.create_flags_group()
         self.controls: crg.RunControls = crg.create_run_controls(
             lambda: QGuiApplication.clipboard().setText(
@@ -78,6 +87,15 @@ class CommandletRunnerWidget(QWidget):
         ):
             root.addWidget(box)
 
+    def _load_cmdlets(self) -> None:
+        proj = self.paths.proj_le.text()
+        cmdlets = load_commandlets(Path(proj)) if proj else load_commandlets(None)
+        current = self.scope.cmdlet_cb.currentText()
+        self.scope.cmdlet_cb.clear()
+        self.scope.cmdlet_cb.addItems(cmdlets)
+        if current in cmdlets:
+            self.scope.cmdlet_cb.setCurrentText(current)
+
     def _browse(self, le: QLineEdit, uproject: bool = False) -> None:
         if uproject:
             path, _ = QFileDialog.getOpenFileName(
@@ -89,7 +107,23 @@ class CommandletRunnerWidget(QWidget):
             )
         if path:
             le.setText(path)
+            if uproject:
+                self._load_cmdlets()
             self._dry_run()
+
+    def _add_cmdlet(self) -> None:
+        name, ok = QInputDialog.getText(self, "Add Commandlet", "Commandlet name:")
+        if ok and name:
+            if self.scope.cmdlet_cb.findText(name) == -1:
+                self.scope.cmdlet_cb.addItem(name)
+            self.scope.cmdlet_cb.setCurrentText(name)
+            proj = self.paths.proj_le.text()
+            if proj:
+                cmds = [
+                    self.scope.cmdlet_cb.itemText(i)
+                    for i in range(self.scope.cmdlet_cb.count())
+                ]
+                save_commandlets(Path(proj), cmds)
 
     def _recipe(self) -> CommandletRecipe:
         flags = CommandletFlags(
@@ -151,6 +185,8 @@ class CommandletRunnerWidget(QWidget):
             save_recipe(Path(self.paths.proj_le.text()), name, self._recipe())
 
     def _apply_recipe(self, r: CommandletRecipe) -> None:
+        if self.scope.cmdlet_cb.findText(r.commandlet) == -1:
+            self.scope.cmdlet_cb.addItem(r.commandlet)
         self.scope.cmdlet_cb.setCurrentText(r.commandlet)
         for le, text in [
             (self.scope.packages_le, ";".join(r.packages)),
@@ -189,4 +225,5 @@ class CommandletRunnerWidget(QWidget):
             for p in profile.project_dir.glob("*.uproject"):
                 self.paths.proj_le.setText(str(p))
                 break
+            self._load_cmdlets()
             self._dry_run()

--- a/docs/commandlet_runner.md
+++ b/docs/commandlet_runner.md
@@ -11,12 +11,12 @@ A dockable panel that turns Unreal commandlets into one-click actions with a cop
 
 ## UI Layout
 1. **Paths & Target**
-   - Browse and validate paths to `UnrealEditor-Cmd.exe` and the target project.
+   - Browse and validate paths to `UnrealEditor-Cmd.exe` and the target project in a single row.
 2. **Commandlet & Scope**
-   - Dropdown of common commandlets (ResavePackages, FixupRedirects, AssetAudit, SizeMap, GatherText).
+   - Dropdown of common commandlets with an **Add** button for project-specific entries.
    - Inputs for packages/paths, collections, and maps with wildcard support.
 3. **Behavior Flags**
-   - Common toggles: `-unattended`, `-nop4`, `-NullRHI`, `-stdout`, `-UTF8Output`.
+   - Common toggles laid out horizontally: `-unattended`, `-nop4`, `-NullRHI`, `-stdout`, `-UTF8Output`.
    - Free-form extra arguments appended verbatim.
 4. **Run Controls**
    - **Dry Run** – compose and show the final CLI without executing.
@@ -27,6 +27,7 @@ A dockable panel that turns Unreal commandlets into one-click actions with a cop
    - Output streams to the main log panel with search and filtering.
 6. **Recipes**
    - Save/load JSON recipes at `<uproject>/.aegies/recipes/commandlets/*.json`.
+   - Custom commandlets persist at `<uproject>/.aegies/commandlets.json`.
    - Auto-save last used settings per profile.
 
 ## Command Construction

--- a/tests/test_commandlets.py
+++ b/tests/test_commandlets.py
@@ -4,7 +4,9 @@ from aegis.modules.commandlets import (
     CommandletFlags,
     CommandletRecipe,
     build_argv,
+    load_commandlets,
     load_recipe,
+    save_commandlets,
     save_recipe,
 )
 
@@ -34,3 +36,14 @@ def test_recipe_roundtrip(tmp_path: Path) -> None:
     path = save_recipe(proj, "sample", recipe)
     loaded = load_recipe(path)
     assert loaded == recipe
+
+
+def test_commandlet_list_roundtrip(tmp_path: Path) -> None:
+    proj = tmp_path / "Game.uproject"
+    proj.write_text("", encoding="utf-8")
+    cmds = load_commandlets(proj)
+    assert "ResavePackages" in cmds
+    cmds.append("CustomCmd")
+    save_commandlets(proj, cmds)
+    loaded = load_commandlets(proj)
+    assert "CustomCmd" in loaded


### PR DESCRIPTION
## Summary
- load default commandlets and persist per-project additions in JSON
- streamline commandlet runner paths & flags layout
- document and test project-level commandlet storage

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd4d6aefa4832598712d34560f607a