### PR TITLE
feat(commandlets): add profile autopick and commandlet editing

### DIFF
--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -68,6 +68,7 @@ class MainWindow(
         self.build_tabs = tabs.build_tabs
         self.uaft_panel = tabs.uaft_panel
         self.pak_panel = tabs.pak_panel
+        self.commandlet_runner = tabs.commandlet_runner
         self.info_bar = tabs.info_bar
         self.setCentralWidget(tabs.central)
 

--- a/aegis/ui/profile_actions.py
+++ b/aegis/ui/profile_actions.py
@@ -12,6 +12,7 @@ from aegis.ui.widgets.env_doc import EnvDocPanel
 from aegis.ui.widgets.batch_builder_panel import BatchBuilderPanel
 from aegis.ui.widgets.uaft_panel import UaftPanel
 from aegis.ui.widgets.pak_iostore_panel import PakIoStorePanel
+from aegis.ui.widgets.commandlet_runner_widget import CommandletRunnerWidget
 from typing import Callable
 
 
@@ -22,6 +23,7 @@ class ProfileActions:
     batch_panel: BatchBuilderPanel
     uaft_panel: UaftPanel
     pak_panel: PakIoStorePanel
+    commandlet_runner: CommandletRunnerWidget
     _log: Callable[[str, str], None]
     setWindowTitle: Callable[[str], None]
 
@@ -110,3 +112,4 @@ class ProfileActions:
         self.batch_panel.update_profile(self.profile)
         self.uaft_panel.update_profile(self.profile)
         self.pak_panel.update_profile(self.profile)
+        self.commandlet_runner.update_profile(self.profile)

--- a/aegis/ui/widgets/commandlet_runner_groups.py
+++ b/aegis/ui/widgets/commandlet_runner_groups.py
@@ -50,6 +50,8 @@ class ScopeGroup:
     box: QGroupBox
     cmdlet_cb: QComboBox
     add_btn: QPushButton
+    edit_btn: QPushButton
+    remove_btn: QPushButton
     packages_le: QLineEdit
     maps_le: QLineEdit
     collection_le: QLineEdit
@@ -61,9 +63,15 @@ def create_scope_group(commandlets: list[str]) -> ScopeGroup:
     cmdlet_cb.setObjectName("cmdlet_cb")
     add_btn = QPushButton("Add")
     add_btn.setObjectName("add_cmdlet_btn")
+    edit_btn = QPushButton("Edit")
+    edit_btn.setObjectName("edit_cmdlet_btn")
+    remove_btn = QPushButton("Remove")
+    remove_btn.setObjectName("remove_cmdlet_btn")
     row_cmdlet = QHBoxLayout()
     row_cmdlet.addWidget(cmdlet_cb)
     row_cmdlet.addWidget(add_btn)
+    row_cmdlet.addWidget(edit_btn)
+    row_cmdlet.addWidget(remove_btn)
     packages_le = QLineEdit()
     maps_le = QLineEdit()
     collection_le = QLineEdit()
@@ -74,7 +82,16 @@ def create_scope_group(commandlets: list[str]) -> ScopeGroup:
     form.addRow("Collection", collection_le)
     box = QGroupBox("Commandlet & Scope")
     box.setLayout(form)
-    return ScopeGroup(box, cmdlet_cb, add_btn, packages_le, maps_le, collection_le)
+    return ScopeGroup(
+        box,
+        cmdlet_cb,
+        add_btn,
+        edit_btn,
+        remove_btn,
+        packages_le,
+        maps_le,
+        collection_le,
+    )
 
 
 @dataclass
@@ -100,6 +117,8 @@ def create_flags_group() -> FlagsGroup:
     flag_utf8.setChecked(True)
     extra_le = QLineEdit()
     grid = QGridLayout()
+    grid.setHorizontalSpacing(5)
+    grid.setVerticalSpacing(5)
     grid.addWidget(flag_unatt, 0, 0)
     grid.addWidget(flag_nop4, 0, 1)
     grid.addWidget(flag_nullrhi, 0, 2)

--- a/aegis/ui/widgets/commandlet_runner_widget.py
+++ b/aegis/ui/widgets/commandlet_runner_widget.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from aegis.core.profile import Profile
 from aegis.core.task_runner import TaskRunner
 from aegis.modules.commandlets import (
+    DEFAULT_COMMANDLETS,
     CommandletFlags,
     CommandletRecipe,
     build_argv,
@@ -45,6 +46,8 @@ class CommandletRunnerWidget(QWidget):
         self.paths: crg.PathsGroup = crg.create_paths_group(self._browse)
         self.scope: crg.ScopeGroup = crg.create_scope_group(load_commandlets(None))
         self.scope.add_btn.clicked.connect(self._add_cmdlet)
+        self.scope.edit_btn.clicked.connect(self._edit_cmdlet)
+        self.scope.remove_btn.clicked.connect(self._remove_cmdlet)
         self.flags: crg.FlagsGroup = crg.create_flags_group()
         self.controls: crg.RunControls = crg.create_run_controls(
             lambda: QGuiApplication.clipboard().setText(
@@ -65,6 +68,9 @@ class CommandletRunnerWidget(QWidget):
             self.scope.packages_le,
             self.scope.maps_le,
             self.scope.collection_le,
+            self.scope.add_btn,
+            self.scope.edit_btn,
+            self.scope.remove_btn,
             self.flags.flag_unatt,
             self.flags.flag_nop4,
             self.flags.flag_nullrhi,
@@ -124,6 +130,41 @@ class CommandletRunnerWidget(QWidget):
                     for i in range(self.scope.cmdlet_cb.count())
                 ]
                 save_commandlets(Path(proj), cmds)
+            self._dry_run()
+
+    def _edit_cmdlet(self) -> None:
+        current = self.scope.cmdlet_cb.currentText()
+        if current in DEFAULT_COMMANDLETS:
+            return
+        name, ok = QInputDialog.getText(
+            self, "Edit Commandlet", "Commandlet name:", text=current
+        )
+        if ok and name and name != current:
+            idx = self.scope.cmdlet_cb.currentIndex()
+            self.scope.cmdlet_cb.setItemText(idx, name)
+            proj = self.paths.proj_le.text()
+            if proj:
+                cmds = [
+                    self.scope.cmdlet_cb.itemText(i)
+                    for i in range(self.scope.cmdlet_cb.count())
+                ]
+                save_commandlets(Path(proj), cmds)
+            self._dry_run()
+
+    def _remove_cmdlet(self) -> None:
+        current = self.scope.cmdlet_cb.currentText()
+        if current in DEFAULT_COMMANDLETS:
+            return
+        idx = self.scope.cmdlet_cb.currentIndex()
+        self.scope.cmdlet_cb.removeItem(idx)
+        proj = self.paths.proj_le.text()
+        if proj:
+            cmds = [
+                self.scope.cmdlet_cb.itemText(i)
+                for i in range(self.scope.cmdlet_cb.count())
+            ]
+            save_commandlets(Path(proj), cmds)
+        self._dry_run()
 
     def _recipe(self) -> CommandletRecipe:
         flags = CommandletFlags(

--- a/tests/test_commandlet_runner_widget.py
+++ b/tests/test_commandlet_runner_widget.py
@@ -1,0 +1,65 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from pathlib import Path
+from PySide6.QtWidgets import QInputDialog
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.modules.commandlets import load_commandlets
+from aegis.ui.widgets.commandlet_runner_widget import CommandletRunnerWidget
+
+
+def _noop_log(_msg: str, _level: str) -> None:
+    pass
+
+
+def test_autopick_paths(tmp_path: Path, qtbot) -> None:
+    engine = tmp_path / "UE"
+    bin_dir = engine / "Engine" / "Binaries" / "Win64"
+    bin_dir.mkdir(parents=True)
+    exe = bin_dir / "UnrealEditor-Cmd.exe"
+    exe.write_text("x")
+    proj_dir = tmp_path / "Proj"
+    proj_dir.mkdir()
+    uproj = proj_dir / "Game.uproject"
+    uproj.write_text("x")
+    profile = Profile(engine_root=engine, project_dir=proj_dir)
+    widget = CommandletRunnerWidget(TaskRunner(), _noop_log)
+    qtbot.addWidget(widget)
+    widget.update_profile(profile)
+    assert widget.paths.exe_le.text() == str(exe)
+    assert widget.paths.proj_le.text() == str(uproj)
+
+
+def test_edit_and_remove_cmdlet(tmp_path: Path, qtbot, monkeypatch) -> None:
+    engine = tmp_path / "UE"
+    bin_dir = engine / "Engine" / "Binaries" / "Win64"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "UnrealEditor-Cmd.exe").write_text("x")
+    proj_dir = tmp_path / "Proj"
+    proj_dir.mkdir()
+    uproj = proj_dir / "Game.uproject"
+    uproj.write_text("x")
+    profile = Profile(engine_root=engine, project_dir=proj_dir)
+    widget = CommandletRunnerWidget(TaskRunner(), _noop_log)
+    qtbot.addWidget(widget)
+    widget.update_profile(profile)
+
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("MyCmd", True))
+    widget._add_cmdlet()
+    cmds = load_commandlets(uproj)
+    assert "MyCmd" in cmds
+
+    monkeypatch.setattr(QInputDialog, "getText", lambda *a, **k: ("NewCmd", True))
+    widget.scope.cmdlet_cb.setCurrentText("MyCmd")
+    widget._edit_cmdlet()
+    cmds = load_commandlets(uproj)
+    assert "NewCmd" in cmds
+    assert "MyCmd" not in cmds
+
+    widget.scope.cmdlet_cb.setCurrentText("NewCmd")
+    widget._remove_cmdlet()
+    cmds = load_commandlets(uproj)
+    assert "NewCmd" not in cmds

--- a/tests/test_commandlets.py
+++ b/tests/test_commandlets.py
@@ -47,3 +47,15 @@ def test_commandlet_list_roundtrip(tmp_path: Path) -> None:
     save_commandlets(proj, cmds)
     loaded = load_commandlets(proj)
     assert "CustomCmd" in loaded
+
+
+def test_commandlet_remove(tmp_path: Path) -> None:
+    proj = tmp_path / "Game.uproject"
+    proj.write_text("", encoding="utf-8")
+    cmds = load_commandlets(proj)
+    cmds.append("TempCmd")
+    save_commandlets(proj, cmds)
+    cmds.remove("TempCmd")
+    save_commandlets(proj, cmds)
+    loaded = load_commandlets(proj)
+    assert "TempCmd" not in loaded


### PR DESCRIPTION
## Summary
- auto-fill commandlet runner paths from active profile
- add edit/remove actions for custom commandlets and tighten flag spacing
- test commandlet runner widget behaviours

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd509f76f0832585aac92c3ea53db9