### PR TITLE
feat(ui): unify test path display and device selection

### DIFF
--- a/aegis/ui/models/build_defaults.py
+++ b/aegis/ui/models/build_defaults.py
@@ -1,0 +1,23 @@
+"""Shared default build options."""
+
+from __future__ import annotations
+
+from typing import List
+
+DEFAULT_CONFIGS: List[str] = [
+    "Debug",
+    "DebugGame",
+    "DebugServer",
+    "DebugEditor",
+    "Development",
+    "DevelopmentServer",
+    "DevelopmentEditor",
+    "Test",
+    "TestServer",
+    "TestEditor",
+    "Shipping",
+    "ShippingServer",
+    "ShippingEditor",
+]
+
+DEFAULT_PLATFORMS: List[str] = ["Win64", "Linux", "Mac", "Android"]

--- a/aegis/ui/widgets/batch_builder_panel.py
+++ b/aegis/ui/widgets/batch_builder_panel.py
@@ -34,27 +34,7 @@ from aegis.modules.uat import Uat
 from aegis.ui.widgets.uat_override_widget import UatOverrideWidget
 from aegis.ui.widgets.task_queue_widget import TaskQueueWidget
 from aegis.ui.models.queued_task import QueuedTask
-
-
-# Include server and editor configurations by default
-DEFAULT_CONFIGS = [
-    "Debug",
-    "DebugGame",
-    "DebugServer",
-    "DebugEditor",
-    "Development",
-    "DevelopmentServer",
-    "DevelopmentEditor",
-    "Test",
-    "TestServer",
-    "TestEditor",
-    "Shipping",
-    "ShippingServer",
-    "ShippingEditor",
-]
-
-# Mac is included for editor builds
-DEFAULT_PLATFORMS = ["Win64", "Linux", "Mac", "Android"]
+from aegis.ui.models.build_defaults import DEFAULT_CONFIGS, DEFAULT_PLATFORMS
 
 # Tasks that support manual command editing
 EDITABLE_TAGS = {

--- a/aegis/ui/widgets/buildgraph_panel.py
+++ b/aegis/ui/widgets/buildgraph_panel.py
@@ -5,19 +5,19 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable, Dict
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
-    QFileDialog,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
     QPushButton,
-    QTabWidget,
     QTextEdit,
     QVBoxLayout,
     QWidget,
     QComboBox,
+    QSizePolicy,
 )
 
 from aegis.core.task_runner import TaskRunner
@@ -62,9 +62,11 @@ class BuildGraphPanel(QWidget):
         self.runner = runner
         self.log = log_cb
 
-        self.runuat_edit = QLineEdit()
-        self.runuat_btn = QPushButton("Browse…")
-        self.runuat_btn.clicked.connect(self._pick_runuat)
+        self.runuat_label = QLabel("RunUAT: (not found)")
+        self.runuat_label.setObjectName("runuat_lbl")
+        self.runuat_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.runuat_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self.runuat_path: Path | None = None
 
         self.script_combo = QComboBox()
         self.script_combo.addItems(list(PRESETS.keys()))
@@ -76,8 +78,6 @@ class BuildGraphPanel(QWidget):
 
         self.preview = QTextEdit()
         self.preview.setReadOnly(True)
-        self.log_view = QTextEdit()
-        self.log_view.setReadOnly(True)
         self.dry_run_btn = QPushButton("Dry Run")
         self.dry_run_btn.clicked.connect(self._dry_run)
         self.run_btn = QPushButton("Run")
@@ -92,7 +92,7 @@ class BuildGraphPanel(QWidget):
         root = QVBoxLayout(self)
         paths = QGroupBox("Paths & Preset")
         lp = QVBoxLayout(paths)
-        lp.addLayout(self._row(QLabel("RunUAT"), self.runuat_edit, self.runuat_btn))
+        lp.addLayout(self._row(self.runuat_label))
         lp.addLayout(self._row(QLabel("Preset"), self.script_combo))
         lp.addLayout(self.vars_form)
         root.addWidget(paths)
@@ -104,10 +104,7 @@ class BuildGraphPanel(QWidget):
         ctrl.addStretch(1)
         root.addLayout(ctrl)
 
-        tabs = QTabWidget()
-        tabs.addTab(self.preview, "Preview")
-        tabs.addTab(self.log_view, "Log")
-        root.addWidget(tabs, 1)
+        root.addWidget(self.preview, 1)
 
     def _row(self, *widgets) -> QHBoxLayout:
         layout = QHBoxLayout()
@@ -127,17 +124,15 @@ class BuildGraphPanel(QWidget):
             self.vars_edits[key] = edit
 
     # ----- File pickers -----
-    def _pick_runuat(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Select RunUAT")
-        if path:
-            self.runuat_edit.setText(path)
-
     # ----- Profile -----
     def update_profile(self, profile: Profile | None) -> None:
         if not profile:
+            self.runuat_label.setText("RunUAT: (not found)")
+            self.runuat_path = None
             return
         runuat = profile.engine_root / "Engine" / "Build" / "BatchFiles" / "RunUAT.bat"
-        self.runuat_edit.setText(str(runuat))
+        self.runuat_label.setText(f"RunUAT: {runuat}")
+        self.runuat_path = runuat
         proj_edit = self.vars_edits.get("Project")
         if proj_edit:
             for uproj in profile.project_dir.glob("*.uproject"):
@@ -151,7 +146,7 @@ class BuildGraphPanel(QWidget):
         script = Path(f"docs/buildgraph/presets/{preset.lower().replace('-', '_')}.xml")
         sets = {k: e.text() for k, e in self.vars_edits.items() if e.text()}
         return BuildGraph(
-            runuat=Path(self.runuat_edit.text()),
+            runuat=self.runuat_path or Path(),
             script=script,
             target="ArchiveClient" if preset != "Tools-Pack" else "ArchiveTools",
             sets=sets,
@@ -168,7 +163,6 @@ class BuildGraphPanel(QWidget):
     def _run(self) -> None:
         argv = self._compose()
         self.preview.setPlainText("\n".join(argv))
-        self.log_view.clear()
         self.runner.start(
             argv,
             lambda s: self._append_log(s, "stdout"),
@@ -178,4 +172,3 @@ class BuildGraphPanel(QWidget):
 
     def _append_log(self, line: str, stream: str) -> None:
         self.log(stream, line)
-        self.log_view.append(f"[{stream}] {line}")

--- a/aegis/ui/widgets/device_list_widget.py
+++ b/aegis/ui/widgets/device_list_widget.py
@@ -1,0 +1,108 @@
+"""Widget for listing and selecting connected devices."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Callable, List
+
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from aegis.core.profile import Profile
+from aegis.core.task_runner import TaskRunner
+from aegis.modules.uaft import Uaft
+
+
+class DeviceListWidget(QWidget):
+    """List connected devices via UAFT."""
+
+    def __init__(
+        self,
+        runner: TaskRunner,
+        log_cb: Callable[[str, str], None],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.runner = runner
+        self.log = log_cb
+        self.uaft: Uaft | None = None
+        self.setObjectName("device_panel")
+
+        self.list_btn = QPushButton("List Devices")
+        self.list_btn.setObjectName("list_devices_btn")
+        self.list_btn.clicked.connect(self._list_devices)
+
+        self.table = QTableWidget(0, 3)
+        self.table.setObjectName("devices_table")
+        self.table.setHorizontalHeaderLabels(["Make", "Model", "Serial"])
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.MultiSelection)
+        self.table.horizontalHeader().setStretchLastSection(True)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.table)
+
+    # ----- Profile -----
+    def update_profile(self, profile: Profile | None) -> None:
+        self.uaft = Uaft(profile.engine_root, profile.project_dir) if profile else None
+
+    # ----- Actions -----
+    def _list_devices(self) -> None:
+        if not self.uaft:
+            self.log("[uaft] UAFT not configured", "error")
+            return
+        lines: List[str] = []
+        argv = self.uaft.devices_argv()
+        self.log(f"[uaft] {' '.join(argv)}", "info")
+        self.runner.start(
+            argv,
+            on_stdout=lines.append,
+            on_stderr=lambda s: self.log(f"[uaft] {s}", "error"),
+            on_exit=lambda code: self._on_devices_exit(code, lines),
+        )
+
+    def _on_devices_exit(self, code: int, lines: List[str]) -> None:
+        if code != 0:
+            self.log(f"[uaft] exit code {code}", "error")
+            return
+        devs = Uaft.parse_devices(lines)
+        self.table.setRowCount(0)
+        for serial in devs:
+            make, model = self._adb_device_info(serial)
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(make))
+            self.table.setItem(row, 1, QTableWidgetItem(model))
+            self.table.setItem(row, 2, QTableWidgetItem(serial))
+        if devs:
+            self.table.selectRow(0)
+
+    def selected_devices(self) -> List[str]:
+        return [
+            self.table.item(idx.row(), 2).text()
+            for idx in self.table.selectionModel().selectedRows()
+        ]
+
+    def _adb_device_info(self, serial: str) -> tuple[str, str]:
+        try:
+            make = subprocess.run(
+                ["adb", "-s", serial, "shell", "getprop", "ro.product.manufacturer"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+            model = subprocess.run(
+                ["adb", "-s", serial, "shell", "getprop", "ro.product.model"],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+            return make or "?", model or serial
+        except Exception:
+            return "?", serial

--- a/aegis/ui/widgets/gauntlet_panel.py
+++ b/aegis/ui/widgets/gauntlet_panel.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import Callable, List
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -16,15 +17,17 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QSpinBox,
-    QTabWidget,
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 
 from aegis.core.task_runner import TaskRunner
 from aegis.core.profile import Profile
 from aegis.modules.gauntlet import Gauntlet
+from aegis.ui.models.build_defaults import DEFAULT_CONFIGS, DEFAULT_PLATFORMS
+from aegis.ui.widgets.device_list_widget import DeviceListWidget
 
 
 class GauntletPanel(QWidget):
@@ -41,21 +44,19 @@ class GauntletPanel(QWidget):
         self.log = log_cb
 
         # Paths
-        self.runuat_edit = QLineEdit()
-        self.runuat_edit.setObjectName("runuat_edit")
-        self.runuat_btn = QPushButton("Browse…")
-        self.runuat_btn.setObjectName("runuat_btn")
-        self.runuat_btn.clicked.connect(self._pick_runuat)
+        self.runuat_label = QLabel("RunUAT: (not found)")
+        self.runuat_label.setObjectName("runuat_lbl")
+        self.runuat_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.runuat_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
-        self.project_edit = QLineEdit()
-        self.project_edit.setObjectName("project_edit")
-        self.project_btn = QPushButton("Browse…")
-        self.project_btn.clicked.connect(self._pick_project)
+        self.editor_label = QLabel("UnrealEditor-Cmd: (not found)")
+        self.editor_label.setObjectName("editor_lbl")
+        self.editor_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.editor_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
 
-        self.editor_edit = QLineEdit()
-        self.editor_edit.setObjectName("editor_edit")
-        self.editor_btn = QPushButton("Browse…")
-        self.editor_btn.clicked.connect(self._pick_editor)
+        self.project_path: Path | None = None
+        self.runuat_path: Path | None = None
+        self.editor_path: Path | None = None
 
         # Scenario
         self.tests_edit = QLineEdit()
@@ -65,13 +66,9 @@ class GauntletPanel(QWidget):
         self.clients_spin.setValue(1)
         self.server_chk = QCheckBox("Run Server")
         self.platform_combo = QComboBox()
-        self.platform_combo.addItems(["Windows", "Android"])
         self.config_combo = QComboBox()
-        self.config_combo.addItems(["Development", "Shipping"])
         self.map_edit = QLineEdit()
-        self.devices_edit = QLineEdit()
-        self.devices_edit.setObjectName("devices_edit")
-        self.devices_edit.setPlaceholderText("adb1234,adb5678")
+        self.device_panel = DeviceListWidget(runner, log_cb)
         self.timeout_spin = QSpinBox()
         self.timeout_spin.setRange(1, 1000)
         self.timeout_spin.setValue(60)
@@ -93,8 +90,6 @@ class GauntletPanel(QWidget):
         # Command + log
         self.preview = QTextEdit()
         self.preview.setReadOnly(True)
-        self.log_view = QTextEdit()
-        self.log_view.setReadOnly(True)
 
         self.dry_run_btn = QPushButton("Dry Run")
         self.dry_run_btn.clicked.connect(self._dry_run)
@@ -103,19 +98,35 @@ class GauntletPanel(QWidget):
         self.stop_btn = QPushButton("Stop")
         self.stop_btn.clicked.connect(self.runner.cancel)
 
+        self._populate_build_options(None)
         self._build_layout()
 
     # ----- UI helpers -----
+    def _populate_build_options(self, profile: Profile | None) -> None:
+        plats = (
+            profile.build_platforms
+            if profile and profile.build_platforms
+            else DEFAULT_PLATFORMS
+        )
+        cfgs = (
+            profile.build_configs
+            if profile and profile.build_configs
+            else DEFAULT_CONFIGS
+        )
+        self.platform_combo.clear()
+        self.platform_combo.addItems(plats)
+        self.config_combo.clear()
+        self.config_combo.addItems(cfgs)
+
     def _build_layout(self) -> None:
         root = QVBoxLayout(self)
 
         paths = QGroupBox("Paths")
-        lp = QVBoxLayout(paths)
-        lp.addLayout(self._row(QLabel("RunUAT"), self.runuat_edit, self.runuat_btn))
-        lp.addLayout(
-            self._row(QLabel("UnrealEditor-Cmd"), self.editor_edit, self.editor_btn)
-        )
-        lp.addLayout(self._row(QLabel("Project"), self.project_edit, self.project_btn))
+        lp = QHBoxLayout(paths)
+        lp.addWidget(self.runuat_label)
+        lp.addSpacing(8)
+        lp.addWidget(self.editor_label)
+        lp.addStretch(1)
         root.addWidget(paths)
 
         scen = QGroupBox("Scenario")
@@ -131,7 +142,8 @@ class GauntletPanel(QWidget):
             )
         )
         ls.addLayout(self._row(QLabel("Map"), self.map_edit))
-        ls.addLayout(self._row(QLabel("Devices"), self.devices_edit))
+        ls.addLayout(self._row(self.device_panel.list_btn))
+        ls.addWidget(self.device_panel)
         ls.addLayout(self._row(QLabel("Timeout"), self.timeout_spin))
         root.addWidget(scen)
 
@@ -162,10 +174,7 @@ class GauntletPanel(QWidget):
         ctrl.addStretch(1)
         root.addLayout(ctrl)
 
-        tabs = QTabWidget()
-        tabs.addTab(self.preview, "Preview")
-        tabs.addTab(self.log_view, "Log")
-        root.addWidget(tabs, 1)
+        root.addWidget(self.preview, 1)
 
     def _row(self, *widgets) -> QHBoxLayout:
         layout = QHBoxLayout()
@@ -176,23 +185,6 @@ class GauntletPanel(QWidget):
         return layout
 
     # ----- File pickers -----
-    def _pick_runuat(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Select RunUAT")
-        if path:
-            self.runuat_edit.setText(path)
-
-    def _pick_project(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Select .uproject", filter="*.uproject"
-        )
-        if path:
-            self.project_edit.setText(path)
-
-    def _pick_editor(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Select UnrealEditor-Cmd")
-        if path:
-            self.editor_edit.setText(path)
-
     def _pick_artifacts(self) -> None:
         path = QFileDialog.getExistingDirectory(self, "Select artifacts root")
         if path:
@@ -200,10 +192,18 @@ class GauntletPanel(QWidget):
 
     # ----- Profile -----
     def update_profile(self, profile: Profile | None) -> None:
+        self._populate_build_options(profile)
+        self.device_panel.update_profile(profile)
         if not profile:
+            self.runuat_label.setText("RunUAT: (not found)")
+            self.editor_label.setText("UnrealEditor-Cmd: (not found)")
+            self.project_path = None
+            self.runuat_path = None
+            self.editor_path = None
             return
         runuat = profile.engine_root / "Engine" / "Build" / "BatchFiles" / "RunUAT.bat"
-        self.runuat_edit.setText(str(runuat))
+        self.runuat_label.setText(f"RunUAT: {runuat}")
+        self.runuat_path = runuat
         editor = (
             profile.engine_root
             / "Engine"
@@ -211,9 +211,11 @@ class GauntletPanel(QWidget):
             / "Win64"
             / "UnrealEditor-Cmd.exe"
         )
-        self.editor_edit.setText(str(editor))
+        self.editor_label.setText(f"UnrealEditor-Cmd: {editor}")
+        self.editor_path = editor
+        self.project_path = None
         for uproj in profile.project_dir.glob("*.uproject"):
-            self.project_edit.setText(str(uproj))
+            self.project_path = uproj
             break
         self._dry_run()
 
@@ -221,7 +223,7 @@ class GauntletPanel(QWidget):
     def _gauntlet(self) -> Gauntlet:
         tests = [t.strip() for t in self.tests_edit.text().split(",") if t.strip()]
         devices: List[str] = []
-        for dev in self._device_list():
+        for dev in self.device_panel.selected_devices():
             if self.platform_combo.currentText() == "Android":
                 devices.append(f"Android@{dev}")
             else:
@@ -240,15 +242,13 @@ class GauntletPanel(QWidget):
             int(self.trace_port.text()) if self.insights_chk.isChecked() else None
         )
         return Gauntlet(
-            runuat=Path(self.runuat_edit.text()),
-            project=Path(self.project_edit.text()),
+            runuat=self.runuat_path or Path(),
+            project=self.project_path or Path(),
             tests=tests,
             platforms=[self.platform_combo.currentText()],
             configuration=self.config_combo.currentText(),
             devices=devices,
-            editor_exe=(
-                Path(self.editor_edit.text()) if self.editor_edit.text() else None
-            ),
+            editor_exe=self.editor_path,
             timeout_minutes=int(self.timeout_spin.value()),
             exec_cmds=";".join(cmds),
             trace_categories=trace_cats,
@@ -266,7 +266,6 @@ class GauntletPanel(QWidget):
     def _run(self) -> None:
         argv = self._compose()
         self.preview.setPlainText("\n".join(argv))
-        self.log_view.clear()
 
         def on_exit(code: int) -> None:
             self._append_log(f"Exit code {code}", "exit")
@@ -274,7 +273,7 @@ class GauntletPanel(QWidget):
                 self.logcat_chk.isChecked()
                 and self.platform_combo.currentText() == "Android"
             ):
-                for dev in self._device_list():
+                for dev in self.device_panel.selected_devices():
                     self._pull_logcat(dev)
 
         self.runner.start(
@@ -286,10 +285,6 @@ class GauntletPanel(QWidget):
 
     def _append_log(self, line: str, stream: str) -> None:
         self.log(stream, line)
-        self.log_view.append(f"[{stream}] {line}")
-
-    def _device_list(self) -> List[str]:
-        return [d.strip() for d in self.devices_edit.text().split(",") if d.strip()]
 
     def _pull_logcat(self, device: str) -> None:
         art = Path(self.artifacts_edit.text()) / "devices" / device

--- a/aegis/ui/widgets/uaft_panel.py
+++ b/aegis/ui/widgets/uaft_panel.py
@@ -21,8 +21,6 @@ from PySide6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QPushButton,
-    QTableWidget,
-    QTableWidgetItem,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -32,6 +30,7 @@ from PySide6.QtWidgets import (
 from aegis.core.profile import Profile
 from aegis.core.task_runner import TaskRunner
 from aegis.modules.uaft import Uaft
+from aegis.ui.widgets.device_list_widget import DeviceListWidget
 
 
 DEFAULT_CMD_FILE = Path(__file__).resolve().parents[3] / "UECommandline.txt"
@@ -85,16 +84,14 @@ class UaftPanel(QWidget):
         self.package = QLineEdit()
         self.package.setPlaceholderText("e.g. com.company.game")
 
-        self.btn_list_devices = QPushButton("List Devices")
+        self.device_panel = DeviceListWidget(runner, log_cb)
+        self.device_panel.table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.device_panel.table.setMinimumHeight(160)
+        self.device_panel.table.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Expanding
+        )
+        self.device_panel.table.itemSelectionChanged.connect(self._device_selected)
         self.btn_list_packages = QPushButton("List Packages")
-
-        self.device_table = QTableWidget(0, 3)
-        self.device_table.setHorizontalHeaderLabels(["Make", "Model", "Serial"])
-        self.device_table.horizontalHeader().setStretchLastSection(True)
-        self.device_table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.device_table.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.device_table.setMinimumHeight(160)
-        self.device_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         self.pkg_list = QListWidget()
         self.pkg_list.setSelectionMode(QListWidget.SingleSelection)
@@ -175,9 +172,9 @@ class UaftPanel(QWidget):
                 ]
             )
         )
-        lc.addLayout(self._row([self.btn_list_devices, self.btn_list_packages]))
+        lc.addLayout(self._row([self.device_panel.list_btn, self.btn_list_packages]))
         dev_pkg = QHBoxLayout()
-        dev_pkg.addWidget(self.device_table, 1)
+        dev_pkg.addWidget(self.device_panel, 1)
         dev_pkg.addWidget(self.pkg_list, 1)
         lc.addLayout(dev_pkg)
         box_conn.setLayout(lc)
@@ -219,9 +216,7 @@ class UaftPanel(QWidget):
         return h
 
     def _connect_signals(self) -> None:
-        self.btn_list_devices.clicked.connect(self._list_devices)
         self.btn_list_packages.clicked.connect(self._list_packages)
-        self.device_table.itemSelectionChanged.connect(self._device_selected)
         self.pkg_list.itemClicked.connect(lambda it: self.package.setText(it.text()))
         self.btn_write_cmd.clicked.connect(self._write_cmd)
         self.btn_refresh_traces.clicked.connect(self._refresh_traces)
@@ -232,6 +227,7 @@ class UaftPanel(QWidget):
     # ----- Profile -----
     def update_profile(self, profile: Optional[Profile]) -> None:
         self.profile = profile
+        self.device_panel.update_profile(profile)
         self._scan()
         self._apply_project_prefix()
         self._load_security_token()
@@ -309,68 +305,15 @@ class UaftPanel(QWidget):
         shown = ["<redacted>" if token and a == token else a for a in argv]
         self.log(f"[uaft] {' '.join(shown)}", "info")
 
-    def _adb_device_info(self, serial: str) -> tuple[str, str]:
-        try:
-            make = subprocess.run(
-                ["adb", "-s", serial, "shell", "getprop", "ro.product.manufacturer"],
-                capture_output=True,
-                text=True,
-                check=False,
-            ).stdout.strip()
-            model = subprocess.run(
-                ["adb", "-s", serial, "shell", "getprop", "ro.product.model"],
-                capture_output=True,
-                text=True,
-                check=False,
-            ).stdout.strip()
-            return make or "?", model or serial
-        except Exception:
-            return "?", serial
-
     # ----- Actions -----
-    def _list_devices(self) -> None:
-        uaft = self._require_uaft()
-        if not uaft:
-            return
-        lines: list[str] = []
-        argv = uaft.devices_argv()
-        self.log(f"[uaft] {' '.join(argv)}", "info")
-        try:
-            self.runner.start(
-                argv,
-                on_stdout=lines.append,
-                on_stderr=lambda s: self.log(f"[uaft] {s}", "error"),
-                on_exit=lambda code: self._on_devices_exit(code, lines),
-            )
-        except Exception as e:  # pragma: no cover - subprocess failures
-            self.log(f"[uaft] {e}", "error")
-
-    def _on_devices_exit(self, code: int, lines: list[str]) -> None:
-        if code != 0:
-            self.log(f"[uaft] exit code {code}", "error")
-            return
-        devs = Uaft.parse_devices(lines)
-        self.device_table.setRowCount(0)
-        for serial in devs:
-            make, model = self._adb_device_info(serial)
-            row = self.device_table.rowCount()
-            self.device_table.insertRow(row)
-            self.device_table.setItem(row, 0, QTableWidgetItem(make))
-            self.device_table.setItem(row, 1, QTableWidgetItem(model))
-            self.device_table.setItem(row, 2, QTableWidgetItem(serial))
-        if devs:
-            self.device_table.selectRow(0)
-            self.serial.setText(devs[0])
-            self._device_selected()
-        self.log(f"[uaft] found {len(devs)} device(s)", "info")
-
     def _device_selected(self) -> None:
-        row = self.device_table.currentRow()
+        table = self.device_panel.table
+        row = table.currentRow()
         if row >= 0:
-            serial = self.device_table.item(row, 2).text()
+            serial = table.item(row, 2).text()
             self.serial.setText(serial)
-            make = self.device_table.item(row, 0).text()
-            model = self.device_table.item(row, 1).text()
+            make = table.item(row, 0).text()
+            model = table.item(row, 1).text()
             if self.pull_base and self.chk_auto_path.isChecked():
                 make_safe = make.replace(" ", "_")
                 model_safe = model.replace(" ", "_")

--- a/tests/test_buildgraph_panel.py
+++ b/tests/test_buildgraph_panel.py
@@ -28,7 +28,7 @@ def test_buildgraph_panel_autofills(tmp_path: Path, qtbot) -> None:
     panel = BuildGraphPanel(TaskRunner(), _noop_log)
     qtbot.addWidget(panel)
     panel.update_profile(profile)
-    assert panel.runuat_edit.text() == str(batch_dir / "RunUAT.bat")
+    assert panel.runuat_path == batch_dir / "RunUAT.bat"
     proj_edit = panel.vars_edits.get("Project")
     assert proj_edit is not None
     assert proj_edit.text() == str(uproj)

--- a/tests/test_device_list_widget.py
+++ b/tests/test_device_list_widget.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from aegis.core.task_runner import TaskRunner
+from aegis.ui.widgets.device_list_widget import DeviceListWidget
+from PySide6.QtWidgets import QTableWidgetItem
+
+
+def _noop_log(_msg: str, _level: str) -> None:
+    pass
+
+
+def test_selected_devices(qtbot) -> None:
+    widget = DeviceListWidget(TaskRunner(), _noop_log)
+    qtbot.addWidget(widget)
+    widget.table.setRowCount(2)
+    widget.table.setItem(0, 0, QTableWidgetItem("A"))
+    widget.table.setItem(0, 1, QTableWidgetItem("B"))
+    widget.table.setItem(0, 2, QTableWidgetItem("serial1"))
+    widget.table.setItem(1, 0, QTableWidgetItem("C"))
+    widget.table.setItem(1, 1, QTableWidgetItem("D"))
+    widget.table.setItem(1, 2, QTableWidgetItem("serial2"))
+    widget.table.selectRow(0)
+    assert widget.selected_devices() == ["serial1"]

--- a/tests/test_gauntlet_panel.py
+++ b/tests/test_gauntlet_panel.py
@@ -28,6 +28,6 @@ def test_gauntlet_panel_autofills(tmp_path: Path, qtbot) -> None:
     panel = GauntletPanel(TaskRunner(), _noop_log)
     qtbot.addWidget(panel)
     panel.update_profile(profile)
-    assert panel.runuat_edit.text() == str(batch_dir / "RunUAT.bat")
-    assert panel.project_edit.text() == str(uproj)
-    assert panel.editor_edit.text() == str(bin_dir / "UnrealEditor-Cmd.exe")
+    assert panel.runuat_path == batch_dir / "RunUAT.bat"
+    assert panel.project_path == uproj
+    assert panel.editor_path == bin_dir / "UnrealEditor-Cmd.exe"


### PR DESCRIPTION
## Summary
- Show RunUAT and UnrealEditor paths as read-only labels in test panels and drop project path row
- Share build configuration/platform defaults and remove inline log tabs
- Add reusable device list subpanel for UAFT and Gauntlet

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6522b91083259750d246e84c64d0