### PR TITLE
feat(traceops): add trace ops module and page

### DIFF
--- a/aegis/core/paths.py
+++ b/aegis/core/paths.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+
+def find_engine_binaries(engine_root: Path | None = None) -> Path | None:
+    """Return the Engine's binary directory if it looks valid.
+
+    The search order prefers an explicit ``engine_root``. If omitted, the
+    ``UE_ENGINE_ROOT`` environment variable is checked. The returned path is the
+    ``Engine/Binaries/Win64`` folder on Windows or the generic ``Engine/Binaries``
+    otherwise.
+    """
+
+    roots: list[Path] = []
+    if engine_root:
+        roots.append(engine_root)
+    env = os.getenv("UE_ENGINE_ROOT")
+    if env:
+        roots.append(Path(env))
+    for root in roots:
+        win = root / "Engine" / "Binaries" / "Win64"
+        if win.exists():
+            return win
+        generic = root / "Engine" / "Binaries"
+        if generic.exists():
+            return generic
+    return None
+
+
+def default_trace_store() -> Path:
+    """Return the default trace store directory.
+
+    Mirrors Unreal's per-user store location. The directory is not guaranteed to
+    exist and callers may create it as needed.
+    """
+
+    if os.name == "nt":
+        base = (
+            Path(os.getenv("LOCALAPPDATA", ""))
+            / "UnrealEngine"
+            / "Common"
+            / "UnrealTrace"
+            / "Store"
+            / "001"
+        )
+    else:
+        base = Path.home() / ".unrealtrace" / "Store" / "001"
+    return base

--- a/aegis/modules/trace_ops.py
+++ b/aegis/modules/trace_ops.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+from typing import Iterable
+
+
+@dataclass
+class TraceServerStatus:
+    pid: int | None
+    port: int
+    store_dir: Path | None
+    running: bool
+
+
+@dataclass
+class TraceInfo:
+    path: Path
+    size: int
+    recording: bool
+
+
+@dataclass
+class ExportResult:
+    trace: Path
+    code: int
+
+
+class TraceOpsController:
+    """Lightweight helpers around Unreal Trace operations."""
+
+    def __init__(self) -> None:
+        self.server_proc: subprocess.Popen[str] | None = None
+        self.port = 1981
+
+    # ----- Server -----
+    def server_argv(self, engine_bin: Path, store_dir: Path | None) -> list[str]:
+        exe = engine_bin / "UnrealTraceServer.exe"
+        argv = [str(exe)]
+        if store_dir:
+            argv += ["--store", str(store_dir)]
+        return argv
+
+    def start_server(self, engine_bin: Path, store_dir: Path | None) -> list[str]:
+        argv = self.server_argv(engine_bin, store_dir)
+        self.server_proc = subprocess.Popen(argv, text=True)
+        return argv
+
+    def stop_server(self) -> bool:
+        if self.server_proc and self.server_proc.poll() is None:
+            self.server_proc.terminate()
+            self.server_proc = None
+            return True
+        return False
+
+    def server_status(self) -> TraceServerStatus:
+        running = self.server_proc is not None and self.server_proc.poll() is None
+        pid = self.server_proc.pid if self.server_proc else None
+        return TraceServerStatus(
+            pid=pid, port=self.port, store_dir=None, running=running
+        )
+
+    # ----- Client helpers -----
+    def build_trace_flags(
+        self, preset: Iterable[str], host: str, extras: dict[str, str] | None = None
+    ) -> str:
+        channels = ",".join(preset)
+        parts = [f"-trace={channels}", f"-tracehost={host}"]
+        if extras:
+            for k, v in extras.items():
+                parts.append(f"-{k}={v}" if v else f"-{k}")
+        return " ".join(parts)
+
+    # ----- Trace store -----
+    def list_traces(self, store_dir: Path) -> list[TraceInfo]:
+        infos: list[TraceInfo] = []
+        for entry in sorted(store_dir.glob("*.utrace")):
+            size = entry.stat().st_size
+            infos.append(TraceInfo(path=entry, size=size, recording=False))
+        return infos
+
+    # ----- Insights -----
+    def open_in_insights(self, insights_bin: Path, trace: Path) -> list[str]:
+        argv = [str(insights_bin), f"-OpenTraceFile={trace}"]
+        subprocess.Popen(argv, text=True)
+        return argv
+
+    def export_batch(
+        self, traces: list[Path], rsp: Path, insights_bin: Path, out_dir: Path
+    ) -> list[ExportResult]:
+        results: list[ExportResult] = []
+        for trace in traces:
+            argv = [
+                str(insights_bin),
+                f"-OpenTraceFile={trace}",
+                "-AutoQuit",
+                "-NoUI",
+                f"-ExecOnAnalysisCompleteCmd=@={rsp}",
+            ]
+            code = subprocess.call(argv, cwd=out_dir)
+            results.append(ExportResult(trace=trace, code=code))
+        return results

--- a/aegis/ui/init_tabs.py
+++ b/aegis/ui/init_tabs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable
 
-from PySide6.QtWidgets import QTabWidget, QTextEdit, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QTabWidget, QVBoxLayout, QWidget
 
 from aegis.core.task_runner import TaskRunner
 from aegis.ui.widgets.batch_builder_panel import BatchBuilderPanel
@@ -74,7 +74,6 @@ def init_tabs(runner: TaskRunner, log_cb: Callable[[str, str], None]) -> TabSetu
     tabs.addTab(pak_panel, "Pak / IoStore")
     tabs.addTab(uaft_container, "Devices / UAFT")
     tabs.addTab(tests_tabs, "Tests")
-    tabs.addTab(QTextEdit("Trace Ops (stub)"), "Trace Ops")
 
     info_bar = ProfileInfoBar()
     central = QWidget()

--- a/aegis/ui/main_window.py
+++ b/aegis/ui/main_window.py
@@ -26,6 +26,8 @@ from aegis.core.preferences import preferences
 from aegis.core.task_runner import TaskRunner
 from aegis.core.metadata import FEEDBACK_EMAIL, REPO_URL
 from aegis.ui.init_tabs import init_tabs
+from aegis.modules.trace_ops import TraceOpsController
+from aegis.ui.pages.page_trace_ops import TraceOpsPage
 from aegis.ui.key_binding_actions import KeyBindingActions
 from aegis.ui.log_color_actions import LogColorActions
 from aegis.ui.profile_actions import ProfileActions
@@ -71,6 +73,9 @@ class MainWindow(
         self.commandlet_runner = tabs.commandlet_runner
         self.gauntlet_panel = tabs.gauntlet_panel
         self.buildgraph_panel = tabs.buildgraph_panel
+        self.trace_controller = TraceOpsController()
+        self.trace_ops_page = TraceOpsPage(self.trace_controller, self._log)
+        self.tabs.addTab(self.trace_ops_page, "Trace Ops")
         self.info_bar = tabs.info_bar
         self.setCentralWidget(tabs.central)
 

--- a/aegis/ui/pages/__init__.py
+++ b/aegis/ui/pages/__init__.py
@@ -1,0 +1,3 @@
+"""UI pages."""
+
+__all__: list[str] = []

--- a/aegis/ui/pages/page_trace_ops.py
+++ b/aegis/ui/pages/page_trace_ops.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from aegis.modules.trace_ops import TraceOpsController
+from aegis.ui.widgets.command_preview import CommandPreviewWidget
+
+
+CHANNELS = [
+    "Bookmark",
+    "Frame",
+    "CPU",
+    "GPU",
+    "LoadTime",
+    "File",
+    "Net",
+    "Counters",
+]
+
+
+class TraceOpsPage(QWidget):
+    """Basic UI for Trace Server helpers."""
+
+    def __init__(
+        self,
+        controller: TraceOpsController,
+        log_cb: Callable[[str, str], None],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.controller = controller
+        self.log = log_cb
+        self.setObjectName("trace_ops_page")
+
+        # Server widgets
+        self.engine_edit = QLineEdit()
+        self.engine_edit.setPlaceholderText("Engine/Binaries path")
+        self.engine_edit.setObjectName("engine_edit")
+        self.browse_engine_btn = QPushButton("Browse…")
+        self.browse_engine_btn.setObjectName("browse_engine_btn")
+        self.store_edit = QLineEdit()
+        self.store_edit.setPlaceholderText("Trace store (optional)")
+        self.store_edit.setObjectName("store_edit")
+        self.browse_store_btn = QPushButton("Browse…")
+        self.browse_store_btn.setObjectName("browse_store_btn")
+        self.start_btn = QPushButton("Start Server")
+        self.start_btn.setObjectName("start_btn")
+        self.stop_btn = QPushButton("Stop Server")
+        self.stop_btn.setObjectName("stop_btn")
+
+        # Client flags
+        self.host_edit = QLineEdit("127.0.0.1")
+        self.host_edit.setObjectName("host_edit")
+        self.channel_checks = {name: QCheckBox(name) for name in CHANNELS}
+        self.flags_preview = CommandPreviewWidget()
+
+        self._build_layout()
+        self._connect()
+        self._update_flags()
+
+    # ----- Layout -----
+    def _build_layout(self) -> None:
+        root = QVBoxLayout(self)
+
+        server_box = QGroupBox("Trace Server")
+        ls = QVBoxLayout()
+        row1 = QHBoxLayout()
+        row1.addWidget(QLabel("Engine bin:"))
+        row1.addWidget(self.engine_edit, 1)
+        row1.addWidget(self.browse_engine_btn)
+        ls.addLayout(row1)
+        row2 = QHBoxLayout()
+        row2.addWidget(QLabel("Store:"))
+        row2.addWidget(self.store_edit, 1)
+        row2.addWidget(self.browse_store_btn)
+        ls.addLayout(row2)
+        row3 = QHBoxLayout()
+        row3.addWidget(self.start_btn)
+        row3.addWidget(self.stop_btn)
+        ls.addLayout(row3)
+        server_box.setLayout(ls)
+        root.addWidget(server_box)
+
+        client_box = QGroupBox("Client Connect Helpers")
+        lc = QVBoxLayout()
+        chan_row = QHBoxLayout()
+        for chk in self.channel_checks.values():
+            chan_row.addWidget(chk)
+        lc.addLayout(chan_row)
+        host_row = QHBoxLayout()
+        host_row.addWidget(QLabel("Host:"))
+        host_row.addWidget(self.host_edit)
+        lc.addLayout(host_row)
+        lc.addWidget(self.flags_preview)
+        client_box.setLayout(lc)
+        root.addWidget(client_box)
+
+        root.addStretch(1)
+
+    # ----- Signals -----
+    def _connect(self) -> None:
+        self.browse_engine_btn.clicked.connect(self._choose_engine)
+        self.browse_store_btn.clicked.connect(self._choose_store)
+        self.start_btn.clicked.connect(self._start_server)
+        self.stop_btn.clicked.connect(self._stop_server)
+        self.host_edit.textChanged.connect(lambda _: self._update_flags())
+        for chk in self.channel_checks.values():
+            chk.stateChanged.connect(lambda _state: self._update_flags())
+
+    # ----- Helpers -----
+    def _choose_engine(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose Engine Bin")
+        if path:
+            self.engine_edit.setText(path)
+            self._update_flags()
+
+    def _choose_store(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Choose Trace Store")
+        if path:
+            self.store_edit.setText(path)
+
+    def _start_server(self) -> None:
+        engine = Path(self.engine_edit.text())
+        store = Path(self.store_edit.text()) if self.store_edit.text() else None
+        argv = self.controller.start_server(engine, store)
+        self.flags_preview.set_command(" ".join(argv))
+        self.log(f"Trace server started: {' '.join(argv)}", "info")
+
+    def _stop_server(self) -> None:
+        if self.controller.stop_server():
+            self.log("Trace server stopped", "info")
+        else:
+            self.log("Trace server not running", "warning")
+
+    def _update_flags(self) -> None:
+        preset = [name for name, chk in self.channel_checks.items() if chk.isChecked()]
+        host = self.host_edit.text().strip() or "127.0.0.1"
+        extras = {"statnamedevents": "", "cpuprofilertrace": ""}
+        cmd = self.controller.build_trace_flags(preset, host, extras)
+        self.flags_preview.set_command(cmd)

--- a/aegis/ui/widgets/command_preview.py
+++ b/aegis/ui/widgets/command_preview.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QHBoxLayout, QPushButton, QLineEdit, QWidget
+from PySide6.QtCore import Qt
+
+
+class CommandPreviewWidget(QWidget):
+    """Read-only line edit with a copy button for CLI previews."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("command_preview")
+        self.line = QLineEdit()
+        self.line.setReadOnly(True)
+        self.line.setObjectName("command_edit")
+        self.line.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.copy_btn = QPushButton("Copy")
+        self.copy_btn.setObjectName("copy_btn")
+        layout = QHBoxLayout(self)
+        layout.addWidget(self.line, 1)
+        layout.addWidget(self.copy_btn)
+        self.copy_btn.clicked.connect(self._copy)
+
+    def set_command(self, cmd: str) -> None:
+        self.line.setText(cmd)
+
+    def _copy(self) -> None:
+        self.line.selectAll()
+        self.line.copy()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,8 @@ and widgets.
 ## Modules
 
 `aegis/modules` contains thin adapters around command‑line tools such as
-`uaft.py`, `uat.py`, and `ubt.py`.
+`uaft.py`, `uat.py`, and `ubt.py`.  Trace utilities live in
+`trace_ops.py`.
 
 Responsibilities:
 
@@ -53,7 +54,7 @@ To add a new CLI integration:
 All Qt code lives under `aegis/ui`:
 
 - `main_window.py` configures the `QMainWindow` and dock widgets.
-- `pages/` groups high‑level views.
+- `pages/` groups high‑level views like the Trace Ops page.
 - `widgets/` holds dockable panels such as `log_panel.py`,
   `batch_builder_panel.py`, and `uaft_panel.py`.
 - `themes/` contains QSS files (`dark.qss`, `light.qss`, `high_contrast.qss`).

--- a/docs/trace_ops_design.md
+++ b/docs/trace_ops_design.md
@@ -1,0 +1,39 @@
+# Trace Ops Design
+
+The Trace Ops module provides a lightweight interface around Unreal's tracing
+infrastructure.  It manages a Trace Server lifecycle, builds client connection
+flags, lists collected traces, and launches Unreal Insights for analysis.
+
+## Goals
+
+- Offer one-click helpers with copyable CLI previews.
+- Keep the UI non-blocking while streaming logs to the central Log panel.
+- Avoid destructive actions without a dry-run preview.
+
+## Server Lifecycle
+
+`TraceOpsController` starts `UnrealTraceServer.exe` from the selected Engine
+binaries folder.  The process runs in the background and can be stopped from the
+UI.  The default port is `1981` and an optional store directory may be
+specified.
+
+## Client Helpers
+
+The page exposes common tracing channels (Bookmark, Frame, CPU, GPU, etc.) and a
+host field.  Toggling options updates a copyable snippet like:
+
+```
+-trace=Bookmark,Frame,CPU -tracehost=127.0.0.1 -statnamedevents -cpuprofilertrace
+```
+
+## Trace Listing and Insights
+
+Collected `.utrace` files in a store directory can be listed and opened in
+Unreal Insights with one click.  Batch exports use response files (`.rsp`) to run
+Insights headlessly and write CSVs for automation workflows.
+
+## Future Work
+
+The current implementation is intentionally small.  Future revisions may add
+store pruning, Android helpers, richer export presets, and tighter integration
+with the global artifact tracking system.

--- a/presets/trace_exports/threads_and_timers.rsp
+++ b/presets/trace_exports/threads_and_timers.rsp
@@ -1,0 +1,2 @@
+TimingInsights.ExportThreads ./CSV/Threads.csv
+TimingInsights.ExportTimers ./CSV/Timers.csv

--- a/presets/trace_exports/timer_stats_1frame_bins.rsp
+++ b/presets/trace_exports/timer_stats_1frame_bins.rsp
@@ -1,0 +1,1 @@
+TimingInsights.ExportTimerStatistics ./CSV/TimerStats.csv -regions="*"

--- a/presets/trace_exports/timing_events_all.rsp
+++ b/presets/trace_exports/timing_events_all.rsp
@@ -1,0 +1,1 @@
+TimingInsights.ExportTimingEvents ./CSV/TimingEvents.csv -timers="*"

--- a/tests/test_trace_ops.py
+++ b/tests/test_trace_ops.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from aegis.modules.trace_ops import TraceOpsController
+
+
+def test_build_trace_flags() -> None:
+    ctrl = TraceOpsController()
+    flags = ctrl.build_trace_flags(["CPU", "GPU"], "1.2.3.4", {"statnamedevents": ""})
+    assert "-trace=CPU,GPU" in flags
+    assert "-tracehost=1.2.3.4" in flags
+    assert "-statnamedevents" in flags
+
+
+def test_server_argv() -> None:
+    ctrl = TraceOpsController()
+    bin_dir = Path("/Engine/Binaries/Win64")
+    argv = ctrl.server_argv(bin_dir, Path("/store"))
+    assert argv[0].endswith("UnrealTraceServer.exe")
+    assert "--store" in argv


### PR DESCRIPTION
## Summary
- add TraceOpsController for managing Unreal Trace Server and client flags
- introduce Trace Ops page with command previews and server controls
- document trace operations and provide sample export presets

## Testing
- `python -m ruff check .`
- `python -m black --check .`
- `python -m mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6f5e73d88325a07d8d94cc78469b