### PR TITLE
fix(ui): remove deprecated HDPI flag and copyable command preview

### DIFF
--- a/aegis/app.py
+++ b/aegis/app.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QCoreApplication, Qt
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QApplication
 import sys
@@ -9,7 +9,6 @@ from aegis.ui.main_window import MainWindow
 
 def main() -> None:
     """Launch the Aegis Toolbelt application."""
-    QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
     QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
         Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
     )

--- a/aegis/ui/widgets/command_preview.py
+++ b/aegis/ui/widgets/command_preview.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtWidgets import QHBoxLayout, QPushButton, QLineEdit, QWidget
-from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QHBoxLayout, QPushButton, QLineEdit, QWidget
 
 
 class CommandPreviewWidget(QWidget):
@@ -13,7 +12,6 @@ class CommandPreviewWidget(QWidget):
         self.line = QLineEdit()
         self.line.setReadOnly(True)
         self.line.setObjectName("command_edit")
-        self.line.setTextInteractionFlags(Qt.TextSelectableByMouse)
         self.copy_btn = QPushButton("Copy")
         self.copy_btn.setObjectName("copy_btn")
         layout = QHBoxLayout(self)
@@ -25,5 +23,4 @@ class CommandPreviewWidget(QWidget):
         self.line.setText(cmd)
 
     def _copy(self) -> None:
-        self.line.selectAll()
-        self.line.copy()
+        QApplication.clipboard().setText(self.line.text())

--- a/tests/test_command_preview_widget.py
+++ b/tests/test_command_preview_widget.py
@@ -1,0 +1,20 @@
+"""Tests for the :class:`CommandPreviewWidget`."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+from pytestqt.qtbot import QtBot
+from PySide6.QtWidgets import QApplication
+
+from aegis.ui.widgets.command_preview import CommandPreviewWidget
+
+
+def test_copy_button_copies_text(qtbot: QtBot) -> None:
+    widget = CommandPreviewWidget()
+    qtbot.addWidget(widget)
+    widget.set_command("echo test")
+    clipboard = QApplication.clipboard()
+    clipboard.clear()
+    widget.copy_btn.click()
+    assert clipboard.text() == "echo test"
+    assert widget.line.isReadOnly()


### PR DESCRIPTION
## Summary
- drop deprecated AA_UseHighDpiPixmaps attribute
- simplify command preview widget and add clipboard test
- copy command text without selecting the field

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd721761108325819fcc94c4f09f43