### PR TITLE
feat(trace_ops): auto-detect engine binaries

### DIFF
--- a/aegis/modules/trace_ops.py
+++ b/aegis/modules/trace_ops.py
@@ -36,8 +36,29 @@ class TraceOpsController:
         self.port = 1981
 
     # ----- Server -----
+    def _find_binary(self, engine_bin: Path, names: Iterable[str]) -> Path | None:
+        candidates = [engine_bin / name for name in names]
+        for sub in engine_bin.iterdir():
+            if sub.is_dir():
+                for name in names:
+                    candidates.append(sub / name)
+        for cand in candidates:
+            if cand.exists():
+                return cand
+        return None
+
+    def find_trace_server_bin(self, engine_bin: Path) -> Path | None:
+        return self._find_binary(
+            engine_bin, ["UnrealTraceServer.exe", "UnrealTraceServer"]
+        )
+
+    def find_insights_bin(self, engine_bin: Path) -> Path | None:
+        return self._find_binary(engine_bin, ["UnrealInsights.exe", "UnrealInsights"])
+
     def server_argv(self, engine_bin: Path, store_dir: Path | None) -> list[str]:
-        exe = engine_bin / "UnrealTraceServer.exe"
+        exe = self.find_trace_server_bin(engine_bin)
+        if not exe:
+            raise FileNotFoundError(f"UnrealTraceServer not found under {engine_bin}")
         argv = [str(exe)]
         if store_dir:
             argv += ["--store", str(store_dir)]

--- a/aegis/ui/pages/page_trace_ops.py
+++ b/aegis/ui/pages/page_trace_ops.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import sys
 from typing import Callable
 
 from PySide6.QtCore import Qt
@@ -61,6 +60,7 @@ class TraceOpsPage(QWidget):
         self.launch_insights_btn = QPushButton("Launch Unreal Insights")
         self.launch_insights_btn.setObjectName("launch_insights_btn")
         self.launch_insights_btn.setEnabled(False)
+        self.insights_bin: Path | None = None
         self.store_edit = QLineEdit()
         self.store_edit.setPlaceholderText("Trace store")
         self.store_edit.setObjectName("store_edit")
@@ -174,17 +174,12 @@ class TraceOpsPage(QWidget):
             self.store_edit.clear()
             self.launch_insights_btn.setEnabled(False)
             return
-        plat = (
-            "Win64"
-            if sys.platform == "win32"
-            else "Linux" if sys.platform == "linux" else "Mac"
-        )
-        bin_path = profile.engine_root / "Engine" / "Binaries" / plat
+        bin_path = profile.engine_root / "Engine" / "Binaries"
         self.engine_label.setText(str(bin_path))
-        self.insights_bin = bin_path / (
-            "UnrealInsights.exe" if sys.platform == "win32" else "UnrealInsights"
+        self.insights_bin = self.controller.find_insights_bin(bin_path)
+        self.launch_insights_btn.setEnabled(
+            self.insights_bin is not None and self.insights_bin.exists()
         )
-        self.launch_insights_btn.setEnabled(self.insights_bin.exists())
         self._store_overridden = False
         self._update_store()
 
@@ -197,7 +192,7 @@ class TraceOpsPage(QWidget):
         self.log(f"Rebuilding Unreal Insights: {' '.join(argv)}", "info")
 
     def _launch_insights(self) -> None:
-        if not getattr(self, "insights_bin", None) or not self.insights_bin.exists():
+        if not self.insights_bin or not self.insights_bin.exists():
             self.log("[insights] Unreal Insights not found", "error")
             return
         argv = self.controller.launch_insights(self.insights_bin)

--- a/docs/trace_ops_design.md
+++ b/docs/trace_ops_design.md
@@ -12,9 +12,10 @@ flags, lists collected traces, and launches Unreal Insights for analysis.
 
 ## Server Lifecycle
 
-`TraceOpsController` starts `UnrealTraceServer.exe` from the selected Engine
-binaries folder.  The process runs in the background and can be stopped from the
-UI.  The default port is `1981` and an optional store directory may be
+`TraceOpsController` starts `UnrealTraceServer.exe` from the Engine binaries
+directory. It automatically searches platform subdirectories to locate the
+correct executable. The process runs in the background and can be stopped from
+the UI. The default port is `1981` and an optional store directory may be
 specified.
 
 ## Client Helpers

--- a/tests/test_trace_ops.py
+++ b/tests/test_trace_ops.py
@@ -11,9 +11,12 @@ def test_build_trace_flags() -> None:
     assert "-statnamedevents" in flags
 
 
-def test_server_argv() -> None:
+def test_server_argv(tmp_path: Path) -> None:
     ctrl = TraceOpsController()
-    bin_dir = Path("/Engine/Binaries/Win64")
-    argv = ctrl.server_argv(bin_dir, Path("/store"))
+    bin_root = tmp_path / "Engine" / "Binaries"
+    plat_dir = bin_root / "Win64"
+    plat_dir.mkdir(parents=True)
+    (plat_dir / "UnrealTraceServer.exe").write_text("x")
+    argv = ctrl.server_argv(bin_root, Path("/store"))
     assert argv[0].endswith("UnrealTraceServer.exe")
     assert "--store" in argv

--- a/tests/test_trace_ops_page.py
+++ b/tests/test_trace_ops_page.py
@@ -17,7 +17,8 @@ def _noop_log(_msg: str, _level: str) -> None:
 def test_profile_auto_paths(tmp_path: Path, qtbot) -> None:
     engine = tmp_path / "UE"
     plat = "Win64" if sys.platform == "win32" else "Linux"
-    bin_dir = engine / "Engine" / "Binaries" / plat
+    bin_root = engine / "Engine" / "Binaries"
+    bin_dir = bin_root / plat
     bin_dir.mkdir(parents=True)
     (
         bin_dir
@@ -29,7 +30,7 @@ def test_profile_auto_paths(tmp_path: Path, qtbot) -> None:
     page = TraceOpsPage(TraceOpsController(), _noop_log)
     qtbot.addWidget(page)
     page.update_profile(profile)
-    assert page.engine_label.text() == str(bin_dir)
+    assert page.engine_label.text() == str(bin_root)
     page.trace_name_edit.setText("MyTrace")
     expected = project_dir / "Unreal Insights" / "MyTrace"
     assert page.store_edit.text() == str(expected)


### PR DESCRIPTION
## Summary
- auto-search platform subdirectories for UnrealTraceServer and UnrealInsights
- load engine binaries path from profile in Trace Ops UI
- document engine binary autodetection and add unit tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd82b67c788325834a8ecf46f21f34