### PR TITLE
fix(trace_ops): normalize engine root paths

### DIFF
--- a/aegis/modules/trace_ops.py
+++ b/aegis/modules/trace_ops.py
@@ -36,23 +36,43 @@ class TraceOpsController:
         self.port = 1981
 
     # ----- Server -----
+    @staticmethod
+    def engine_dir(engine_root: Path) -> Path:
+        """Return the Engine directory for a given Unreal root."""
+        eng = engine_root / "Engine"
+        return eng if eng.is_dir() else engine_root
+
+    @classmethod
+    def engine_bin_path(cls, engine_root: Path) -> Path:
+        """Return the ``Engine/Binaries`` directory for ``engine_root``.
+
+        ``engine_root`` should point to the Unreal repository root or the
+        ``Engine`` subdirectory. Do **not** include ``Binaries``; this helper
+        appends it after normalizing the root.
+        """
+        return cls.engine_dir(engine_root) / "Binaries"
+
     def _find_binary(self, engine_bin: Path, names: Iterable[str]) -> Path | None:
+        """Search ``engine_bin`` and its subfolders for an executable."""
         candidates = [engine_bin / name for name in names]
-        for sub in engine_bin.iterdir():
-            if sub.is_dir():
-                for name in names:
-                    candidates.append(sub / name)
+        if engine_bin.exists():
+            for sub in engine_bin.iterdir():
+                if sub.is_dir():
+                    for name in names:
+                        candidates.append(sub / name)
         for cand in candidates:
             if cand.exists():
                 return cand
         return None
 
     def find_trace_server_bin(self, engine_bin: Path) -> Path | None:
+        """Locate the Unreal Trace Server executable."""
         return self._find_binary(
             engine_bin, ["UnrealTraceServer.exe", "UnrealTraceServer"]
         )
 
     def find_insights_bin(self, engine_bin: Path) -> Path | None:
+        """Locate the Unreal Insights executable."""
         return self._find_binary(engine_bin, ["UnrealInsights.exe", "UnrealInsights"])
 
     def server_argv(self, engine_bin: Path, store_dir: Path | None) -> list[str]:
@@ -114,8 +134,9 @@ class TraceOpsController:
         return argv
 
     def rebuild_insights(self, engine_root: Path) -> list[str]:
+        engine_dir = self.engine_dir(engine_root)
         script_name = "RunUAT.bat" if sys.platform == "win32" else "RunUAT.sh"
-        script = engine_root / "Engine" / "Build" / "BatchFiles" / script_name
+        script = engine_dir / "Build" / "BatchFiles" / script_name
         argv = [str(script), "BuildUnrealInsights"]
         subprocess.Popen(argv, text=True)
         return argv

--- a/aegis/ui/pages/page_trace_ops.py
+++ b/aegis/ui/pages/page_trace_ops.py
@@ -174,7 +174,9 @@ class TraceOpsPage(QWidget):
             self.store_edit.clear()
             self.launch_insights_btn.setEnabled(False)
             return
-        bin_path = profile.engine_root / "Engine" / "Binaries"
+        bin_path = self.controller.engine_bin_path(profile.engine_root)
+        # TraceOpsController searches ``bin_path`` for UnrealTraceServer and
+        # UnrealInsights executables.
         self.engine_label.setText(str(bin_path))
         self.insights_bin = self.controller.find_insights_bin(bin_path)
         self.launch_insights_btn.setEnabled(

--- a/tests/test_profile_actions_trace_ops.py
+++ b/tests/test_profile_actions_trace_ops.py
@@ -55,3 +55,19 @@ def test_profile_change_updates_trace_ops_page(tmp_path: Path, qtbot) -> None:
     actions.profile = profile
     actions._profile_changed()
     assert page.engine_label.text() == str(bin_root)
+
+
+def test_profile_change_engine_subdir(tmp_path: Path, qtbot) -> None:
+    engine = tmp_path / "UE" / "Engine"
+    plat = "Win64" if sys.platform == "win32" else "Linux"
+    bin_root = engine / "Binaries"
+    (bin_root / plat).mkdir(parents=True)
+    project_dir = tmp_path / "Proj"
+    project_dir.mkdir()
+    profile = Profile(engine_root=engine, project_dir=project_dir)
+    page = TraceOpsPage(TraceOpsController(), _noop_log)
+    qtbot.addWidget(page)
+    actions = _StubActions(page)
+    actions.profile = profile
+    actions._profile_changed()
+    assert page.engine_label.text() == str(bin_root)

--- a/tests/test_trace_ops.py
+++ b/tests/test_trace_ops.py
@@ -20,3 +20,12 @@ def test_server_argv(tmp_path: Path) -> None:
     argv = ctrl.server_argv(bin_root, Path("/store"))
     assert argv[0].endswith("UnrealTraceServer.exe")
     assert "--store" in argv
+
+
+def test_engine_bin_path_handles_engine_subdir(tmp_path: Path) -> None:
+    ctrl = TraceOpsController()
+    repo_root = tmp_path / "UE"
+    engine_dir = repo_root / "Engine"
+    (engine_dir / "Binaries").mkdir(parents=True)
+    assert ctrl.engine_bin_path(repo_root) == engine_dir / "Binaries"
+    assert ctrl.engine_bin_path(engine_dir) == engine_dir / "Binaries"

--- a/tests/test_trace_ops_page.py
+++ b/tests/test_trace_ops_page.py
@@ -35,3 +35,23 @@ def test_profile_auto_paths(tmp_path: Path, qtbot) -> None:
     expected = project_dir / "Unreal Insights" / "MyTrace"
     assert page.store_edit.text() == str(expected)
     assert page.launch_insights_btn.isEnabled()
+
+
+def test_profile_engine_subdir(tmp_path: Path, qtbot) -> None:
+    engine_root = tmp_path / "UE" / "Engine"
+    plat = "Win64" if sys.platform == "win32" else "Linux"
+    bin_root = engine_root / "Binaries"
+    bin_dir = bin_root / plat
+    bin_dir.mkdir(parents=True)
+    (
+        bin_dir
+        / ("UnrealInsights.exe" if sys.platform == "win32" else "UnrealInsights")
+    ).write_text("x")
+    project_dir = tmp_path / "Proj"
+    project_dir.mkdir()
+    profile = Profile(engine_root=engine_root, project_dir=project_dir)
+    page = TraceOpsPage(TraceOpsController(), _noop_log)
+    qtbot.addWidget(page)
+    page.update_profile(profile)
+    assert page.engine_label.text() == str(bin_root)
+    assert page.launch_insights_btn.isEnabled()


### PR DESCRIPTION
## Summary
- handle engine roots pointing to either repo root or the Engine folder itself
- guard binary lookup when the bin path is missing
- update tests for Engine subfolder profiles
- document expected engine bin path and searched binaries

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd86acf2e08325b538207ef0ea6264