### PR TITLE
feat(cpp): add ThreadWorker wrapper

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,5 +1,7 @@
 # Coding Standards
 
+## Python
+
 - **Python version**: 3.11 or newer.
 - **Type hints**: required for all functions and methods.
 - **Formatting**: `black` for code style, `ruff` for linting.
@@ -11,3 +13,9 @@
 - **Tests**: add or update unit and functional tests for every change.
 - **Automation**: run `ruff check .`, `black --check .`, `mypy`, and `PYTHONPATH=$PWD pytest` before pushing. CI verifies these checks on `main`, `dev`, `feat/**`, and `maintenance/**` branches.
 - **Dependencies and tooling**: keep requirements, pre-commit hooks, and GitHub Actions workflows in sync when introducing new tools.
+
+## C++
+
+- **Naming**: methods and free functions use PascalCase. Variables use camelCase; data members are prefixed with `m`. File names use PascalCase.
+- **Braces**: opening braces appear on their own line (Allman style).
+- **Conditionals**: format as `if ( condition )` with braces on subsequent lines.

--- a/cpp/ThreadWorker.cpp
+++ b/cpp/ThreadWorker.cpp
@@ -1,0 +1,41 @@
+#include "ThreadWorker.h"
+
+ThreadWorker::ThreadWorker(ThreadFunc func)
+{
+    mThread = nullptr;
+    mFunc = func;
+}
+
+void ThreadWorker::Start()
+{
+    if ( mThread == nullptr && mFunc != nullptr )
+    {
+        mThread = new std::thread(mFunc);
+    }
+}
+
+void ThreadWorker::Join()
+{
+    if ( mThread != nullptr && mThread->joinable() )
+    {
+        mThread->join();
+    }
+}
+
+void ThreadWorker::Stop()
+{
+    if ( mThread != nullptr )
+    {
+        if ( mThread->joinable() )
+        {
+            mThread->join();
+        }
+        delete mThread;
+        mThread = nullptr;
+    }
+}
+
+ThreadWorker::~ThreadWorker()
+{
+    Stop();
+}

--- a/cpp/ThreadWorker.h
+++ b/cpp/ThreadWorker.h
@@ -1,0 +1,23 @@
+#ifndef THREADWORKER_H
+#define THREADWORKER_H
+
+#include <thread>
+
+class ThreadWorker
+{
+public:
+    using ThreadFunc = void (*)(void);
+
+    explicit ThreadWorker(ThreadFunc func = nullptr);
+
+    void Start();
+    void Join();
+    void Stop();
+    ~ThreadWorker();
+
+private:
+    std::thread* mThread;
+    ThreadFunc mFunc;
+};
+
+#endif // THREADWORKER_H

--- a/tests/test_ThreadWorker.py
+++ b/tests/test_ThreadWorker.py
@@ -1,0 +1,48 @@
+import subprocess
+from pathlib import Path
+
+
+def test_ThreadWorker(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cpp_dir = repo_root / "cpp"
+
+    main_src = tmp_path / "main.cpp"
+    main_src.write_text(
+        """#include <iostream>
+#include \"ThreadWorker.h\"
+
+void Run()
+{
+    std::cout << \"thread ran\" << std::endl;
+}
+
+int main()
+{
+    ThreadWorker worker(Run);
+    worker.Start();
+    worker.Join();
+    worker.Stop();
+    return 0;
+}
+"""
+    )
+
+    executable = tmp_path / "test_ThreadWorker"
+    subprocess.run(
+        [
+            "g++",
+            "-std=c++17",
+            str(cpp_dir / "ThreadWorker.cpp"),
+            str(main_src),
+            "-I",
+            str(cpp_dir),
+            "-pthread",
+            "-o",
+            str(executable),
+        ],
+        check=True,
+    )
+    result = subprocess.run(
+        [str(executable)], capture_output=True, text=True, check=True
+    )
+    assert "thread ran" in result.stdout


### PR DESCRIPTION
## Summary
- add ThreadWorker class wrapping std::thread with start, join, stop APIs
- document C++ coding conventions including PascalCase file names and m-prefixed members
- cover ThreadWorker with a compile-and-run test

## Testing
- `ruff check .`
- `black --check .`
- `mypy`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd968093208325a441877b01ddb2d2